### PR TITLE
Prod patches: game_states save race fix + SW/save-race regression tests

### DIFF
--- a/web/cypress.config.ts
+++ b/web/cypress.config.ts
@@ -20,6 +20,7 @@ const profiles: Record<string, Cypress.EndToEndConfigOptions> = {
       'cypress/e2e/mission-delivery-debrief.cy.ts',
       'cypress/e2e/mine-then-deliver-flow.cy.ts',
       'cypress/e2e/coming-soon-missions-wall.cy.ts',
+      'cypress/e2e/service-worker-caching.cy.ts',
     ],
     // Portrait canvas: existing tests target the 402px canvas, not the desktop layout.
     // m3-territory.cy.ts overrides viewport per-test where desktop behaviour is needed.

--- a/web/cypress/e2e/game-state-save-race.cy.ts
+++ b/web/cypress/e2e/game-state-save-race.cy.ts
@@ -1,0 +1,37 @@
+// Regression test for a real prod 400 seen on POST .../game_states/records.
+//
+// Root cause: two near-simultaneous first-saves for the same brand-new user
+// (e.g. two tabs/devices opening the game at once) both attempt create(),
+// and the loser gets PocketBase's real unique-constraint rejection shape
+// (validation_not_unique). The old recovery path looked the record up with
+// getFirstListItem(`user = "..."`), which has its own read-after-write race
+// window against the just-committed winner record. useAuthSync.saveRemoteState
+// now creates with an explicit, deterministic id (== userId), so the loser
+// can recover with a direct update(userId, ...) — no lookup, no race window.
+
+describe('game_states save race recovery', () => {
+  it('recovers via a direct update(userId, ...) when create loses the unique-constraint race, without any lookup request', () => {
+    cy.intercept('POST', '**/api/collections/game_states/records', {
+      statusCode: 400,
+      body: {
+        data: { user: { code: 'validation_not_unique', message: 'Value must be unique.' } },
+        message: 'Failed to create record.',
+        status: 400,
+      },
+    }).as('pbGameStateCreateConflict')
+
+    cy.intercept('PATCH', '**/api/collections/game_states/records/e2e-user', {
+      statusCode: 200,
+      body: { id: 'e2e-user' },
+    }).as('pbGameStateRecoveryUpdate')
+
+    // preset/preview mode skips backend persistence entirely (see
+    // GameProvider's isPreview gate), so this must be a plain, non-preview
+    // visit for the persist effect to ever run.
+    cy.visit('/game')
+    cy.contains('BEGIN OPERATIONS', { timeout: 15000 }).should('be.visible')
+
+    cy.wait('@pbGameStateCreateConflict', { timeout: 20000 })
+    cy.wait('@pbGameStateRecoveryUpdate', { timeout: 20000 })
+  })
+})

--- a/web/cypress/e2e/service-worker-caching.cy.ts
+++ b/web/cypress/e2e/service-worker-caching.cy.ts
@@ -1,0 +1,71 @@
+// Regression test for the sw.js bug where dynamic screen routes
+// (/game/hub, /game/market, ...) matched the same '/game/' prefix used
+// for static assets and were served cache-first. That meant whichever
+// screen a device first cached (commonly /game/market, the post-mission
+// debrief landing screen) was served forever from cache regardless of
+// live game state. See public/sw.js.
+
+function registerServiceWorker(win: Cypress.AUTWindow) {
+  return win.navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
+    .then(() => win.navigator.serviceWorker.ready)
+    .then(() => {
+      if (win.navigator.serviceWorker.controller) return
+      return new Promise<void>(resolve => {
+        win.navigator.serviceWorker.addEventListener('controllerchange', () => resolve(), { once: true })
+      })
+    })
+}
+
+describe('Service worker caching strategy', () => {
+  before(() => {
+    cy.visit('/game', { onBeforeLoad(win) { win.localStorage.clear() } })
+    cy.window().then(win => registerServiceWorker(win))
+  })
+
+  after(() => {
+    cy.window().then(async win => {
+      const regs = await win.navigator.serviceWorker.getRegistrations()
+      await Promise.all(regs.map(r => r.unregister()))
+      const keys = await win.caches.keys()
+      await Promise.all(keys.map(k => win.caches.delete(k)))
+    })
+  })
+
+  it('never serves a stale cached response for a screen route, but still cache-firsts real static assets', () => {
+    cy.window().then(async win => {
+      const cacheKeys = await win.caches.keys()
+      expect(cacheKeys, 'service worker created a shell cache').to.have.length.greaterThan(0)
+      const cache = await win.caches.open(cacheKeys[0])
+
+      // Poison the cache with fake stale responses for two screen routes, as
+      // if the device had cached them once before (very common for
+      // /game/market — the post-mission debrief landing screen) and the
+      // game state had since moved on.
+      await cache.put(
+        new win.Request(`${win.location.origin}/game/hub`),
+        new win.Response('STALE_CACHED_SCREEN_MARKER', { status: 200, headers: { 'Content-Type': 'text/html' } }),
+      )
+      await cache.put(
+        new win.Request(`${win.location.origin}/game/market`),
+        new win.Response('STALE_CACHED_SCREEN_MARKER', { status: 200, headers: { 'Content-Type': 'text/html' } }),
+      )
+
+      const hubBody = await win.fetch('/game/hub').then(res => res.text())
+      expect(hubBody, '/game/hub must not be served from the poisoned cache').not.to.include('STALE_CACHED_SCREEN_MARKER')
+
+      const marketBody = await win.fetch('/game/market').then(res => res.text())
+      expect(marketBody, '/game/market must not be served from the poisoned cache').not.to.include('STALE_CACHED_SCREEN_MARKER')
+
+      // A file extension in the path is what marks a real static asset
+      // (public/game/assets/*, .scene.json files, etc.) — these should
+      // still be served from cache without hitting the network.
+      const staticUrl = `${win.location.origin}/game/assets/cache-test-marker.json`
+      await cache.put(
+        new win.Request(staticUrl),
+        new win.Response('{"marker":"STALE_STATIC_MARKER"}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      )
+      const staticBody = await win.fetch(staticUrl).then(res => res.text())
+      expect(staticBody, 'real static /game/ assets should still be cache-first').to.include('STALE_STATIC_MARKER')
+    })
+  })
+})

--- a/web/lib/contexts/useAuthSync.ts
+++ b/web/lib/contexts/useAuthSync.ts
@@ -88,16 +88,22 @@ export function useAuthSync({
     }
 
     try {
-      const record = await pbLandnam.collection('game_states').create(payload)
+      // Set the record's own id to the (deterministic, already-unique) userId
+      // on first create. Two tabs/devices opening a brand-new session at the
+      // same time both reach this branch with backendRecordId.current still
+      // null and can race here -- the loser's create() 400s on the unique
+      // constraint. Because the id is deterministic rather than server-
+      // generated, the loser already knows the winner's record id without
+      // needing a getFirstListItem lookup, which avoids a real race window:
+      // Fly's read path could still return a 404 for a row that had just
+      // committed a moment earlier via the winning create.
+      const record = await pbLandnam.collection('game_states').create({ id: userId, ...payload })
       backendRecordId.current = record.id
     } catch (createErr: unknown) {
-      // UNIQUE constraint: a record already exists but we couldn't load it (backend
-      // was unavailable on session start). Look it up and update instead.
       const status = responseStatus(createErr)
       if (status !== 400 && status !== 409) throw createErr
-      const existing = await pbLandnam.collection('game_states').getFirstListItem(`user = "${userId}"`)
-      backendRecordId.current = existing.id
-      await pbLandnam.collection('game_states').update(existing.id, payload)
+      backendRecordId.current = userId
+      await pbLandnam.collection('game_states').update(userId, payload)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- Fixes the `game_states` create race that produced `POST .../game_states/records 400` in prod: two concurrent first-saves for the same brand-new user now recover via a direct `update(userId, ...)` instead of a racy `getFirstListItem` lookup. Reproduced and verified the fix directly against the live `signal-k-landnam.fly.dev` backend.
- Adds `cypress/e2e/service-worker-caching.cy.ts` — regression test for the sw.js cache-first screen-route bug already shipped to main (177ca9fc).
- Adds `cypress/e2e/game-state-save-race.cy.ts` — regression test for the save-race fix above (offline profile, no live backend needed).

Workspace ticket: `projects/landnam/tickets/sprint-2026-07-18-landnam/prod-patches-market-redirect-savestate-race-2026-07-14.md`
Plate: STS #260

## Test plan
- [x] `npm run typecheck`
- [ ] Full offline Cypress suite (in progress)
- [ ] Verify on the Vercel preview deploy for this branch before merging to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)