### PR TITLE
Fix mission-setup-frame/card first-paint glitch

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -329,6 +329,11 @@ button { cursor: pointer; }
   border: 1px solid rgba(135,207,250,0.22);
   border-radius: 14px;
   background: linear-gradient(180deg, rgba(9,18,31,0.78), rgba(5,10,18,0.88));
+  /* Forces its own compositing layer on mount. Without this, content painted
+     inside this nested position:absolute + overflow:hidden frame (e.g. the
+     rocket stat values / rocket image on Select Rocket and Confirm Rocket)
+     can fail to paint on first render until any scroll forces a repaint. */
+  transform: translateZ(0);
 }
 
 .mission-setup-card {
@@ -338,6 +343,7 @@ button { cursor: pointer; }
   border: 1px solid rgba(245,166,35,0.32);
   border-radius: 14px;
   background: linear-gradient(180deg, rgba(18,34,54,0.78) 0%, rgba(10,18,29,0.86) 100%);
+  transform: translateZ(0);
 }
 
 .mission-setup-card-scroll {


### PR DESCRIPTION
## Summary
- Speculative CSS fix for the rocket-stat/rocket-image first-paint glitch found during a live prod playtest today: `transform: translateZ(0)` on `.mission-setup-frame`/`.mission-setup-card` forces a compositing layer immediately instead of relying on a later repaint (which scrolling was triggering as a side effect).

Workspace ticket: `projects/landnam/tickets/sprint-2026-07-18-landnam/prod-patches-market-redirect-savestate-race-2026-07-14.md` (item 3)
Plate: STS #260

## Test plan
- [ ] Verify on the Vercel preview deploy for this branch: Select Rocket / Confirm Rocket screens show stat values and rocket image on first load without needing to scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)