### PR TITLE
Contractor tier visual identity marks

### DIFF
--- a/web/components/game/MissionCard.tsx
+++ b/web/components/game/MissionCard.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import type { Mission, Contractor, MineralMeta } from '@/lib/data'
 import TutorialHighlight from '@/components/game/TutorialHighlight'
+import ContractorMark from '@/components/ui/ContractorMark'
 
 type CardState = 'available' | 'locked' | 'cooldown' | 'completed'
 
@@ -92,13 +93,11 @@ export default function MissionCard({
           width: 76, flex: 'none', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,
           padding: '14px 8px', borderRight: `1px solid ${accent}30`, background: 'var(--ln-surface)',
         }}>
-          <div style={{
-            width: 36, height: 36, borderRadius: 999, border: `2px solid ${accent}`,
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            font: '700 13px var(--ln-font-display)', color: accent,
-          }}>
-            {contractor?.initial ?? 'OP'}
-          </div>
+          <ContractorMark
+            initial={contractor?.initial ?? 'OP'}
+            color={accent}
+            uiRole={contractor?.uiRole ?? 'starter'}
+          />
           <div style={{ textAlign: 'center', font: '700 10px var(--ln-font-display)', color: 'var(--ln-text)', textTransform: 'uppercase', letterSpacing: '0.02em', lineHeight: 1.15 }}>
             {contractor?.name ?? 'Free Ops'}
           </div>

--- a/web/components/ui/ContractorMark.tsx
+++ b/web/components/ui/ContractorMark.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import React from 'react'
+import type { ContractorSlot } from '@/lib/data'
+
+// Contractor tier visual identity (STS-239) — a small role-keyed geometric
+// glyph behind the initials, same "shape + color + label, no emoji"
+// vocabulary as OreShapeIcon (MiningScreen). Distinguishes contractor tiers
+// (uiRole) at a glance instead of every dossier reading as an identical
+// initials circle regardless of role.
+type UiRole = ContractorSlot['uiRole']
+
+function RoleGlyph({ role, color, size }: { role: UiRole; color: string; size: number }) {
+  const s = size
+  const mid = s / 2
+  switch (role) {
+    case 'command':
+      // Diamond — authority / directs other contractors' priority.
+      return <polygon points={`${mid},0 ${s},${mid} ${mid},${s} 0,${mid}`} fill="none" stroke={color} strokeWidth={1.5} opacity={0.55} />
+    case 'science':
+      // Hexagon — precision / research.
+      return (
+        <polygon
+          points={[0, 1, 2, 3, 4, 5].map(i => {
+            const a = (Math.PI / 3) * i - Math.PI / 2
+            return `${mid + mid * Math.cos(a)},${mid + mid * Math.sin(a)}`
+          }).join(' ')}
+          fill="none" stroke={color} strokeWidth={1.5} opacity={0.55}
+        />
+      )
+    case 'bulk':
+      // Square — bulk / cargo volume.
+      return <rect x={s * 0.12} y={s * 0.12} width={s * 0.76} height={s * 0.76} fill="none" stroke={color} strokeWidth={1.5} opacity={0.55} />
+    case 'prospect':
+      // Triangle — prospecting / pointing toward new deposits.
+      return <polygon points={`${mid},0 ${s},${s} 0,${s}`} fill="none" stroke={color} strokeWidth={1.5} opacity={0.55} />
+    case 'starter':
+    default:
+      // Ring — entry tier, no distinguishing angularity yet.
+      return <circle cx={mid} cy={mid} r={mid - 1} fill="none" stroke={color} strokeWidth={1.5} opacity={0.55} />
+  }
+}
+
+export default function ContractorMark({
+  initial,
+  color,
+  uiRole,
+  size = 36,
+}: {
+  initial: string
+  color: string
+  uiRole: UiRole
+  size?: number
+}) {
+  return (
+    <div style={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ position: 'absolute', inset: 0 }} aria-hidden="true">
+        <RoleGlyph role={uiRole} color={color} size={size} />
+      </svg>
+      <div style={{
+        position: 'absolute', inset: 0,
+        borderRadius: 999, border: `2px solid ${color}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        font: `700 ${Math.round(size * 0.36)}px var(--ln-font-display)`, color,
+      }}>
+        {initial}
+      </div>
+    </div>
+  )
+}

--- a/web/game-context.tsx
+++ b/web/game-context.tsx
@@ -36,6 +36,7 @@ const MISSION_CONTROL_CONTRACTOR: Contractor = {
   mineralPreferences: [],
   payoutPremium: 0,
   affinityBonusPerMission: 0,
+  uiRole: 'command',
 }
 
 const TRANSIT_TELESCOPE_TARGET: Target = {

--- a/web/lib/catalog.ts
+++ b/web/lib/catalog.ts
@@ -104,6 +104,7 @@ export function toContractor(r: any): Contractor {
       mineralPreferences,
       payoutPremium: 0.2,
       affinityBonusPerMission: 0.025,
+      uiRole: 'starter',
     }),
     id: r.slug,
     name: r.name ?? fallback?.name ?? r.slug,
@@ -114,6 +115,7 @@ export function toContractor(r: any): Contractor {
     mineralPreferences,
     payoutPremium: r.payout_premium ?? fallback?.payoutPremium ?? 0.2,
     affinityBonusPerMission: r.affinity_bonus_per_mission ?? fallback?.affinityBonusPerMission ?? 0.025,
+    uiRole: fallback?.uiRole ?? 'starter',
   }
 }
 

--- a/web/lib/data/contractors.ts
+++ b/web/lib/data/contractors.ts
@@ -205,6 +205,7 @@ export function toContractor(slot: ContractorSlot): Contractor {
     mineralPreferences: slot.mineralPreferences,
     payoutPremium: slot.payoutPremium,
     affinityBonusPerMission: slot.affinityBonusPerMission,
+    uiRole: slot.uiRole,
   }
 }
 

--- a/web/lib/data/types.ts
+++ b/web/lib/data/types.ts
@@ -163,6 +163,7 @@ export interface Contractor {
   mineralPreferences: string[]
   payoutPremium: number
   affinityBonusPerMission: number
+  uiRole: ContractorSlot['uiRole']
 }
 
 export interface ContractorSlot {

--- a/web/lib/mission-board.test.ts
+++ b/web/lib/mission-board.test.ts
@@ -26,6 +26,7 @@ function makeContractor(id: string, unlockTier: number): Contractor {
     mineralPreferences: [],
     payoutPremium: 0.2,
     affinityBonusPerMission: 0.025,
+    uiRole: 'starter',
   }
 }
 


### PR DESCRIPTION
## Summary
- Every contractor rendered as an identical initials-in-a-circle regardless of `uiRole` (starter/bulk/prospect/command/science) — no visual distinction between tiers.
- Adds `ContractorMark`: a role-keyed geometric glyph (ring/square/triangle/diamond/hexagon) behind the initials, same shape+color+label vocabulary as `MiningScreen`'s `OreShapeIcon`. No emoji, no bespoke art asset needed — procedural SVG.
- Threads `uiRole` through the `Contractor` type end to end so the mark is available wherever a `Contractor` object already flows (mission cards today; dossier/other surfaces can reuse it).

Addresses STS-239 (Concept: Contractor tier visual identity). Groundwork toward STS-240/241 (Nightjar Systems / Pioneer Works "face") and STS-235 (contractor dossier card) — those specifically ask for bespoke per-contractor art, which this generic system doesn't replace; left open with a note.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 279/279 passing
- [x] Manual Cypress-driven screenshot verification (throwaway spec, not committed): mission board renders correctly, role glyph visible behind initials on zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)