### PR TITLE
SR3 coming-soon tease + launchpad upgrade confirmation

### DIFF
--- a/web/components/game/ConfirmActionSheet.tsx
+++ b/web/components/game/ConfirmActionSheet.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import React from 'react'
+import { UI_ZONES } from '@/lib/ui-zones'
+
+interface ConfirmActionSheetProps {
+  eyebrow: string
+  title: string
+  description: string
+  confirmLabel: string
+  onConfirm: () => void
+  onDismiss: () => void
+}
+
+// Bottom-sheet confirm/cancel gate for costly, irreversible actions —
+// same slide-up shape as SaveProgressPrompt, but for a plain confirm
+// rather than a form. First use: Upgrade Launchpad fired immediately on
+// click for a flat ₣1B with no confirmation step.
+export default function ConfirmActionSheet({ eyebrow, title, description, confirmLabel, onConfirm, onDismiss }: ConfirmActionSheetProps) {
+  return (
+    <div data-ui-zone={UI_ZONES.modalOverlay} style={{ position: 'absolute', inset: 0, zIndex: 89, display: 'flex', alignItems: 'flex-end' }}>
+      <div onClick={onDismiss} style={{ position: 'absolute', inset: 0, background: 'rgba(3,6,12,0.7)' }} />
+      <div style={{
+        position: 'relative', width: '100%',
+        background: 'linear-gradient(180deg, #0d1c30, #060d18)',
+        borderTopLeftRadius: 20, borderTopRightRadius: 20,
+        border: '1px solid rgba(245,166,35,0.5)',
+        padding: '18px 16px 26px',
+        boxShadow: '0 -12px 40px rgba(0,0,0,0.6)',
+        animation: 'gate-up 360ms cubic-bezier(.16,1,.3,1)',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 10 }}>
+          <div style={{ width: 40, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.25)' }} />
+        </div>
+
+        <div style={{ fontFamily: 'var(--ln-font-display)', fontSize: 9, fontWeight: 800, letterSpacing: '0.22em', color: 'var(--ln-amber)', textTransform: 'uppercase' }}>{eyebrow}</div>
+        <div style={{ fontFamily: 'var(--ln-font-display)', fontSize: 18, fontWeight: 800, color: '#e6efff', marginTop: 2 }}>{title}</div>
+        <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 12, color: '#a9b8ce', marginTop: 4, lineHeight: 1.4 }}>
+          {description}
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 14 }}>
+          <button
+            type="button"
+            onClick={onConfirm}
+            data-testid="confirm-action-confirm"
+            style={{
+              width: '100%', padding: '15px', borderRadius: 12, border: 'none', cursor: 'pointer',
+              background: 'linear-gradient(180deg, #ffcf7a 0%, #f5a623 100%)',
+              color: '#06121f',
+              fontFamily: 'var(--ln-font-display)', fontSize: 14, fontWeight: 800,
+              letterSpacing: '0.12em', textTransform: 'uppercase',
+              boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.4), 0 4px 0 rgba(0,0,0,0.3)',
+            }}
+          >
+            {confirmLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            data-testid="confirm-action-dismiss"
+            style={{
+              background: 'transparent', border: 'none', cursor: 'pointer',
+              fontFamily: 'var(--ln-font-body)', fontSize: 12, color: '#5d7390',
+              textDecoration: 'underline', padding: 4,
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/game/screens/HubScreen.tsx
+++ b/web/components/game/screens/HubScreen.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react'
 import type { Player, Screen } from '@/game-context'
 import ProgressionCard from '@/components/game/ProgressionCard'
 import { ComingSoonSheet, SPRINT_AFTER_NEXT_UTC } from '@/components/game/ComingSoonSheet'
+import ConfirmActionSheet from '@/components/game/ConfirmActionSheet'
 import { TutorialCompleteSheet, useTutorialCompleteAck } from '@/components/game/TutorialCompleteSheet'
 import { Scene } from '@/lib/engine/Scene'
 import type { EntityData } from '@/lib/engine/types'
@@ -39,6 +40,7 @@ export default function HubScreen({ player, hasCoach, onGoBuilding, onNav, onUpg
   const [plotEntities, setPlotEntities] = useState<EntityData[]>(DEFAULT_PLOTS)
   const [subsurface, setSubsurface] = useState(false)
   const [comingSoon, setComingSoon] = useState<{ feature: string; description: string; target?: Date } | null>(null)
+  const [confirmingLaunchpadUpgrade, setConfirmingLaunchpadUpgrade] = useState(false)
   const [tessQueueCount, setTessQueueCount] = useState(0)
   const { show: showTutorialComplete, dismiss: dismissTutorialComplete } = useTutorialCompleteAck(player.missionsDone, FREE_OPS_START_MISSIONS_DONE)
   const placed = player.placed ?? []
@@ -266,6 +268,17 @@ export default function HubScreen({ player, hasCoach, onGoBuilding, onNav, onUpg
         </>
       )}
 
+      {confirmingLaunchpadUpgrade && onUpgradeLaunchpad && (
+        <ConfirmActionSheet
+          eyebrow="Upgrade"
+          title="Upgrade Launchpad"
+          description="Spend ₣1,000,000,000 to permanently upgrade the launchpad. This can't be undone."
+          confirmLabel="Confirm Upgrade (₣1B)"
+          onConfirm={() => { onUpgradeLaunchpad(); setConfirmingLaunchpadUpgrade(false) }}
+          onDismiss={() => setConfirmingLaunchpadUpgrade(false)}
+        />
+      )}
+
       {/* Bottom toolbar — hidden during tutorial */}
       {!hasCoach && (
         <div style={{ position: 'absolute', left: 0, right: 0, bottom: 110, zIndex: 20, display: 'flex', justifyContent: 'center', gap: 8 }}>
@@ -289,7 +302,7 @@ export default function HubScreen({ player, hasCoach, onGoBuilding, onNav, onUpg
                     </button>
                   )}
                   {player.placed.includes('launchpad') && !player.launchpadUpgraded && onUpgradeLaunchpad && (
-                    <button onClick={onUpgradeLaunchpad} style={{ padding: '5px 14px', background: 'rgba(245,166,35,0.15)', backdropFilter: 'blur(6px)', border: '1px solid rgba(245,166,35,0.5)', borderRadius: 999, fontFamily: 'var(--ln-font-display)', fontSize: 9, fontWeight: 700, letterSpacing: '0.14em', color: '#f5a623', textTransform: 'uppercase', cursor: 'pointer' }}>
+                    <button onClick={() => setConfirmingLaunchpadUpgrade(true)} style={{ padding: '5px 14px', background: 'rgba(245,166,35,0.15)', backdropFilter: 'blur(6px)', border: '1px solid rgba(245,166,35,0.5)', borderRadius: 999, fontFamily: 'var(--ln-font-display)', fontSize: 9, fontWeight: 700, letterSpacing: '0.14em', color: '#f5a623', textTransform: 'uppercase', cursor: 'pointer' }}>
                       Upgrade Launchpad (₣1B)
                     </button>
                   )}

--- a/web/lib/data/rockets.ts
+++ b/web/lib/data/rockets.ts
@@ -27,6 +27,20 @@ export const STARTER_ROCKETS: StarterRocket[] = [
     unlockHint: 'Unlocks after M1',
   },
   {
+    // Coming-soon tease, not yet purchasable — decided cost/unlock condition
+    // (rocket-and-room-system.md, 2026-06-18) is 4.0B F at L3/M3, but stats
+    // aren't finalized so this stays locked like sr4/sr5 until they are.
+    id: 'sr3',
+    name: 'Starter Rocket 3',
+    tier: 3,
+    costFrancs: 4_000_000_000,
+    missionsRequired: 999,
+    locked: true,
+    stats: { cargo: 0, maxOrbit: 0, drillTier: 0 },
+    img: '/parts/basic_hull_t1.png',
+    unlockHint: 'Unlocks at L3/M3 · 4.0B F',
+  },
+  {
     id: 'sr4',
     name: 'Starter Rocket 4',
     tier: 4,


### PR DESCRIPTION
## Summary
- **STS-231**: SR3 was missing entirely from `STARTER_ROCKETS` (a gap between SR2 and the SR4/SR5 locked stubs). Added as a locked stub using the decided cost/unlock condition from `rocket-and-room-system.md` (2026-06-18: 4.0B F at L3/M3) — reuses the existing locked-rocket card pattern, renders identically to SR4/SR5.
- **STS-244**: "Upgrade Launchpad (₣1B)" fired immediately on click with no confirmation step, unusual for a ~1B-franc spend. Added `ConfirmActionSheet` (reusable bottom-sheet confirm/cancel, same shape as `SaveProgressPrompt`) in front of it.

Note on STS-244: the ticket title says "room-upgrade" but the only unconfirmed costly-spend action in the game today is the launchpad upgrade — there's no room-upgrade mechanic in AssemblyScreen or the ship customiser. Interpreted as the closest real match; flagged on the ticket.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 279/279 passing
- [x] Manual Cypress-driven verification (throwaway spec, not committed): SR3 renders as locked/coming-soon identically to SR4/SR5; upgrade confirm sheet blocks the spend until confirmed, and francs/launchpadUpgraded state only changes after confirming (asserted directly against game state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)