### PR TITLE
Ship the Sprint 11 launchpad UI and personalised updates

### DIFF
--- a/web/app/game/(main)/layout.tsx
+++ b/web/app/game/(main)/layout.tsx
@@ -8,10 +8,10 @@ import TutorialCoach from '@/components/game/TutorialCoach'
 import SaveProgressPrompt from '@/components/game/SaveProgressPrompt'
 import UnlockPopup from '@/components/game/UnlockPopup'
 import BottomTabBar from '@/components/layout/BottomTabBar'
-import Sidebar from '@/components/Sidebar/Sidebar'
 import BackendStatus from '@/components/game/BackendStatus'
 import LandnamSyncStatus from '@/components/game/LandnamSyncStatus'
 import { PushOptIn } from '@/components/game/PushOptIn'
+import ContentUpdateNotice from '@/components/game/ContentUpdateNotice'
 import FeedbackButton from '@/components/ui/FeedbackButton'
 import SurveySheet from '@/components/ui/SurveySheet'
 import ToastLayer from '@/components/ui/ToastLayer'
@@ -19,6 +19,7 @@ import { initPostHog } from '@/lib/posthog'
 import DevShortcuts from '@/components/dev/DevShortcuts'
 import AuthGateSheet from '@/components/game/AuthGateSheet'
 import SettingsSheet from '@/components/game/SettingsSheet'
+import SettingsButton from '@/components/game/SettingsButton'
 import TerritoryClaimPopup from '@/components/game/TerritoryClaimPopup'
 import { UI_ZONES } from '@/lib/ui-zones'
 
@@ -130,16 +131,16 @@ function GameChrome({ children }: { children: ReactNode }) {
       <div className="portrait-canvas">
         <BackendStatus />
         <LandnamSyncStatus />
-        {/* zIndex 6 keeps PushOptIn below ProgressionCard (8). At 12 it sat
-            above the progression cards and, once its label wrapped, covered the
-            first one — the Skill Tree button stopped responding to taps. It is
-            already *behind* the top HUD (18), which is why only the first few
-            characters ever show; that placement collision is tracked separately
-            and is a design call, not fixed here. */}
+        {/* Mission alerts have a reserved desktop slot to the left of the
+            horizontal resource HUD. They are hidden at compact widths rather
+            than wrapping over progression controls. */}
         {game.player.freeOperations && currentScreen === 'hub' && (
-          <div data-ui-zone={UI_ZONES.ambientPrompt} style={{ position: 'absolute', top: 12, right: 12, zIndex: 6 }}>
+          <div data-ui-zone={UI_ZONES.ambientPrompt} className="hub-push-opt-in">
             <PushOptIn userId={game.authUserId ?? undefined} />
           </div>
+        )}
+        {currentScreen === 'hub' && (
+          <SettingsButton onClick={() => setSettingsOpen(true)} />
         )}
         <DevShortcuts />
 
@@ -148,6 +149,13 @@ function GameChrome({ children }: { children: ReactNode }) {
 
         <ToastLayer toasts={game.toasts} onDismiss={game.dismissToast} />
         {showFeedback && <FeedbackButton />}
+        {['hub', 'missions', 'launchpad'].includes(currentScreen) && (
+          <ContentUpdateNotice
+            player={game.player}
+            blocked={!!game.popup || !!coach || game.upgradePromptOpen || game.authGateOpen || !!game.pendingTerritoryClaimFor}
+            onNavigate={screen => game.go(screen)}
+          />
+        )}
         <SurveySheet blockWhile={!!game.popup || !!coach || !!game.pendingTerritoryClaimFor} />
         {showNav && <BottomTabBar current={currentNav} onNav={goFromNav} />}
 
@@ -196,14 +204,8 @@ function GameChrome({ children }: { children: ReactNode }) {
         )}
       </div>
 
-      {/* Sidebar (position:fixed, desktop only) lives outside .portrait-canvas
-          on purpose: that box has `isolation: isolate` + `overflow: hidden`
-          for the mobile-canvas illusion, which scopes/clips a nested fixed
-          descendant's effective stacking in ways that made the sidebar
-          unreliable to click on desktop (Liam, 2026-07-04: "buttons in the
-          sidebar on desktop do not work"). Keeping it a sibling of
-          .portrait-canvas inside .game-stage removes that ambiguity. */}
-      <Sidebar current={currentNav} onNav={goFromNav} onSettings={() => setSettingsOpen(true)} />
+      {/* Navigation is scene-owned on desktop; settings remains available as
+          a small hub affordance instead of reviving the overlapping rail. */}
       {settingsOpen && <SettingsSheet onClose={() => setSettingsOpen(false)} />}
     </main>
   )

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./launchpad-screen.css";
 
 /* ============================================================
    LANDNAM — Colors & Type
@@ -1090,55 +1091,29 @@ html[data-coach-target="build-structure-strip"] [data-coach-id="build-structure-
   100% { opacity: 0; transform: translate(calc(-50% + var(--sx, 0px)), calc(-50% + var(--sy, 0px))); }
 }
 
-/* ============================================================
-   SCENE-PANEL SPIKE (STS-630) — Launchpad only
-   ============================================================
-   CSS approximation of the scene-panel model (see ZenNotes
-   landnam-scene-panel-background-direction-2026-07-31): the panel
-   background is a lit surface, not a flat color fill, and instrument
-   chrome uses thick opaque outlines instead of thin glass hairlines.
-   This is a stand-in for a future PixiJS-rendered control-room
-   background — not the final rendering technique. Scoped under
-   .ln-scene-launchpad so it cannot leak into any other screen. */
-.ln-scene-launchpad {
-  --scene-sky-top:    #bfe8f5;
-  --scene-sky-mid:    #eaf8ea;
-  --scene-ground:     #6fae63;
-  --scene-sun:        rgba(255, 235, 150, 0.9);
-  --scene-ink:        #14171c;
-  --scene-card-bg:    #ffffff;
-  --scene-card-text:  #14171c;
-  --scene-card-muted: #3f4854;
+/* Keep the Earth Base scene chrome in separate reserved bands. The previous
+   110px action-rail offset landed directly on the building status pills at
+   short landscape heights. */
+.hub-action-rail { bottom: 110px; }
 
-  background:
-    radial-gradient(140px 90px at 82% 12%, var(--scene-sun), transparent 70%),
-    linear-gradient(0deg, var(--scene-ground) 0%, var(--scene-ground) 20%, transparent 20%),
-    linear-gradient(180deg, var(--scene-sky-top) 0%, var(--scene-sky-mid) 55%, var(--scene-ground) 100%);
+.hub-push-opt-in {
+  position: absolute;
+  top: 16px;
+  right: 196px;
+  z-index: 19;
+  max-width: 210px;
+}
+.hub-push-opt-in button,
+.hub-push-opt-in div { white-space: nowrap; }
+
+@media (min-width: 1024px) {
+  .hub-action-rail { bottom: var(--ln-s-5); }
 }
 
-.ln-instrument-card {
-  background: var(--scene-card-bg);
-  border: 3px solid var(--scene-ink);
-  border-radius: 10px;
-  box-shadow: 0 4px 0 var(--scene-ink);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+@media (max-width: 1023px) {
+  .hub-push-opt-in { display: none; }
 }
 
-.ln-instrument-label {
-  font-family: var(--ln-font-display);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--scene-card-muted);
-  font-weight: 700;
-}
-
-.ln-instrument-value {
-  font-family: var(--ln-font-display);
-  font-size: 16px;
-  color: var(--scene-card-text);
-  font-weight: 700;
+@media (orientation: landscape) and (max-height: 600px) {
+  .hub-progression-stack { bottom: 76px !important; }
 }

--- a/web/app/launchpad-screen.css
+++ b/web/app/launchpad-screen.css
@@ -1,0 +1,216 @@
+/* STS-641 visual reset: Launchpad is a place, not a dashboard. */
+.ln-scene-launchpad { background: #07101c; }
+.launchpad-visual-scene {
+  position: absolute;
+  inset: 72px 0 62px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #07101f 0%, #0d2745 47%, #214f68 70%, #162e26 70%, #0b1713 100%);
+}
+.launchpad-visual-scene::before,
+.launchpad-visual-scene::after { content: ''; position: absolute; left: -5%; right: -5%; pointer-events: none; }
+.launchpad-visual-scene::before {
+  bottom: 26%; height: 34%; background: #183c3a; opacity: .78;
+  clip-path: polygon(0 80%, 8% 55%, 17% 74%, 27% 35%, 38% 72%, 48% 47%, 58% 76%, 69% 28%, 79% 68%, 89% 41%, 100% 74%, 100% 100%, 0 100%);
+}
+.launchpad-visual-scene::after {
+  bottom: 0; height: 28%; border-top: 1px solid rgba(112,217,234,.18);
+  background: linear-gradient(180deg, #10271e 0 36%, #301f0c 36% 100%);
+}
+.launchpad-stars {
+  position: absolute; inset: 0 0 28%; z-index: 1; opacity: .55;
+  background-image:
+    radial-gradient(circle at 9% 16%, #d9f5ff 0 1px, transparent 1.4px),
+    radial-gradient(circle at 29% 31%, #d9f5ff 0 1px, transparent 1.4px),
+    radial-gradient(circle at 47% 12%, #d9f5ff 0 1px, transparent 1.4px),
+    radial-gradient(circle at 69% 28%, #d9f5ff 0 1px, transparent 1.4px),
+    radial-gradient(circle at 88% 10%, #d9f5ff 0 1px, transparent 1.4px);
+}
+.launchpad-orbit-line {
+  position: absolute; z-index: 2; top: 4%; left: 13%; width: 74%; height: 40%;
+  border: 1px solid rgba(112,217,234,.2); border-bottom-color: transparent; border-radius: 50% 50% 0 0;
+}
+.launchpad-satellite {
+  position: absolute; z-index: 3; top: 7%; left: 63%; color: #8de8f4;
+  display: flex; align-items: center; gap: 10px; transform: rotate(-4deg);
+}
+.launchpad-satellite svg { width: 92px; filter: drop-shadow(0 0 10px rgba(112,217,234,.32)); }
+.launchpad-satellite div { display: flex; flex-direction: column; }
+.launchpad-satellite strong { color: #f3fbff; font: 800 18px var(--ln-font-mono); }
+.launchpad-satellite span { color: #8de8f4; font: 700 9px var(--ln-font-display); letter-spacing: .2em; }
+.launchpad-scene-object {
+  position: absolute; z-index: 6; padding: 0; border: 0; background: transparent; color: #fff;
+  display: flex; flex-direction: column; align-items: center; cursor: default;
+}
+button.launchpad-scene-object { cursor: pointer; }
+.launchpad-object-label {
+  position: relative; z-index: 3; min-width: 142px; margin-top: 8px; padding: 7px 12px;
+  border: 1px solid rgba(255,255,255,.45); border-radius: 999px; background: rgba(6,11,20,.9);
+  box-shadow: 0 8px 20px rgba(0,0,0,.35); display: flex; flex-direction: column; align-items: center; gap: 1px; white-space: nowrap;
+}
+.launchpad-object-label small { color: #9fb0c5; font: 700 8px var(--ln-font-display); letter-spacing: .16em; }
+.launchpad-object-label strong { color: #f5f8ff; font: 800 10px var(--ln-font-display); letter-spacing: .08em; }
+.launchpad-object-label--center strong { color: #65e38f; }
+.launchpad-station { left: 8%; bottom: 13%; width: 25%; }
+.launchpad-object-art { position: relative; width: min(210px, 76%); aspect-ratio: 1.45; display: grid; place-items: end center; }
+.launchpad-object-art img { width: 100%; image-rendering: pixelated; filter: drop-shadow(0 16px 18px rgba(0,0,0,.5)); }
+.launchpad-station.is-blueprint .launchpad-object-art {
+  border: 2px dashed rgba(112,217,234,.62); border-radius: 50% 50% 12px 12px; background: rgba(112,217,234,.06);
+  box-shadow: inset 0 0 28px rgba(112,217,234,.08), 0 0 24px rgba(112,217,234,.08);
+}
+.launchpad-station.is-blueprint .launchpad-object-art img { opacity: .22; filter: grayscale(1) sepia(.2) hue-rotate(135deg) saturate(5) drop-shadow(0 0 8px rgba(112,217,234,.8)); }
+.launchpad-station.is-blueprint .launchpad-object-label { border-color: rgba(112,217,234,.8); }
+.launchpad-station.is-blueprint .launchpad-object-label strong { color: #86e7f4; }
+.launchpad-build-plus {
+  position: absolute; inset: 50% auto auto 50%; width: 40px; height: 40px; transform: translate(-50%,-50%);
+  border: 1px solid #86e7f4; border-radius: 50%; background: rgba(6,16,26,.92); color: #86e7f4;
+  font: 300 28px/36px var(--ln-font-display); font-style: normal; box-shadow: 0 0 18px rgba(112,217,234,.4);
+}
+.launchpad-tower { left: 50%; bottom: 12%; width: 28%; transform: translateX(-50%); }
+.launchpad-tower-art { position: relative; width: min(250px, 88%); height: 260px; }
+.launchpad-tower-gantry { position: absolute; left: 18%; bottom: 18px; width: 78px; height: 226px; image-rendering: pixelated; }
+.launchpad-tower-rocket { position: absolute; left: 50%; bottom: 31px; width: 205px; transform: translateX(-50%) rotate(-90deg); filter: drop-shadow(0 8px 14px rgba(0,0,0,.55)); }
+.launchpad-tower-deck { position: absolute; left: 50%; bottom: 0; width: 230px; transform: translateX(-50%); image-rendering: pixelated; }
+.launchpad-rocket { right: 5%; bottom: 16%; width: 31%; }
+.launchpad-rocket-art { position: relative; width: min(360px, 95%); height: 150px; display: grid; place-items: center; }
+.launchpad-rocket-art img { position: relative; z-index: 2; width: 100%; filter: drop-shadow(0 18px 18px rgba(0,0,0,.6)); }
+.launchpad-rocket-glow { position: absolute; left: 5%; right: 5%; bottom: 18%; height: 14px; border-radius: 50%; background: rgba(112,217,234,.2); filter: blur(12px); }
+.launchpad-rocket:hover img,
+.launchpad-station:hover .launchpad-object-art { filter: brightness(1.12) drop-shadow(0 0 18px rgba(112,217,234,.22)); }
+.launchpad-scene-object.is-guided { z-index: 11; }
+.launchpad-scene-object.is-guided .launchpad-object-art,
+.launchpad-scene-object.is-guided .launchpad-tower-art,
+.launchpad-scene-object.is-guided .launchpad-rocket-art {
+  border-radius: 18px;
+  filter: brightness(1.08) drop-shadow(0 0 22px rgba(112,217,234,.75));
+}
+.launchpad-scene-object.is-guided .launchpad-object-label {
+  border-color: #86e7f4;
+  box-shadow: 0 0 0 3px rgba(112,217,234,.14), 0 10px 24px rgba(0,0,0,.5);
+}
+.launchpad-satellite.is-guided {
+  z-index: 11;
+  padding: 8px 12px;
+  border: 1px solid #86e7f4;
+  border-radius: 12px;
+  background: rgba(5,14,25,.82);
+  box-shadow: 0 0 0 3px rgba(112,217,234,.12), 0 0 28px rgba(112,217,234,.3);
+}
+.launchpad-guide {
+  position: absolute;
+  z-index: 14;
+  top: 18px;
+  left: 18px;
+  width: min(340px, calc(100% - 36px));
+  padding: 16px;
+  border: 1px solid rgba(134,231,244,.78);
+  border-radius: 12px;
+  background: rgba(5,11,20,.96);
+  box-shadow: 0 18px 44px rgba(0,0,0,.48), 0 0 24px rgba(112,217,234,.1);
+  color: #f4f8ff;
+}
+.launchpad-guide-close {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  background: transparent;
+  color: #9fb0c5;
+  font: 400 22px/1 var(--ln-font-display);
+}
+.launchpad-guide-close:hover { color: #f4f8ff; }
+.launchpad-guide-kicker {
+  display: block;
+  padding-right: 32px;
+  color: #86e7f4;
+  font: 800 9px var(--ln-font-display);
+  letter-spacing: .18em;
+}
+.launchpad-guide h2 {
+  margin: 7px 32px 5px 0;
+  color: #f4f8ff;
+  font: 800 19px/1.15 var(--ln-font-display);
+}
+.launchpad-guide-copy {
+  display: block;
+  max-width: 295px;
+  color: #b9c7d9;
+  font: 500 12px/1.45 var(--ln-font-body);
+}
+.launchpad-guide-footer {
+  margin-top: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.launchpad-guide-progress { display: flex; gap: 5px; }
+.launchpad-guide-progress i {
+  display: block;
+  width: 16px;
+  height: 3px;
+  border-radius: 3px;
+  background: rgba(169,184,206,.3);
+}
+.launchpad-guide-progress i.is-current { background: #86e7f4; box-shadow: 0 0 8px rgba(112,217,234,.5); }
+.launchpad-guide-actions { display: flex; align-items: center; gap: 6px; }
+.launchpad-guide-actions button {
+  min-width: 62px;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid rgba(169,184,206,.35);
+  border-radius: 6px;
+  background: rgba(255,255,255,.04);
+  color: #cbd6e6;
+  font: 800 9px var(--ln-font-display);
+  letter-spacing: .12em;
+}
+.launchpad-guide-actions button.is-primary { border-color: #86e7f4; background: #86e7f4; color: #07101c; }
+.launchpad-ground-line { position: absolute; z-index: 5; left: 4%; right: 4%; bottom: 20%; height: 2px; background: rgba(112,217,234,.22); box-shadow: 0 0 16px rgba(112,217,234,.18); }
+.launchpad-scene-rail {
+  position: absolute; z-index: 22; left: 0; right: 0; bottom: 0; height: 62px; padding: 9px 16px;
+  border-top: 1px solid rgba(112,217,234,.22); background: rgba(6,9,15,.97);
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+}
+.launchpad-rail-status,
+.launchpad-rail-actions { display: flex; align-items: center; gap: 8px; }
+.launchpad-rail-status span { color: #91a1b6; font: 700 9px var(--ln-font-display); letter-spacing: .14em; white-space: nowrap; }
+.launchpad-rail-status i { display: inline-block; width: 6px; height: 6px; margin-right: 5px; border-radius: 50%; background: #5ad07e; box-shadow: 0 0 8px #5ad07e; }
+.launchpad-rail-actions button {
+  height: 40px; padding: 0 14px; border: 1px solid rgba(169,184,206,.28); border-radius: 8px;
+  background: rgba(255,255,255,.035); color: #cbd6e6; font: 800 10px var(--ln-font-display); letter-spacing: .12em;
+  display: inline-flex; align-items: center; gap: 7px;
+}
+.launchpad-rail-actions button svg { width: 15px; height: 15px; fill: none; stroke: currentColor; stroke-width: 1.8; }
+.launchpad-rail-actions button.is-primary { border-color: #70d9ea; background: #70d9ea; color: #07101c; box-shadow: 0 0 18px rgba(112,217,234,.24); }
+@media (max-width: 860px) {
+  .launchpad-guide { top: 10px; left: 10px; width: min(310px, calc(100% - 20px)); padding: 12px; }
+  .launchpad-guide h2 { font-size: 16px; }
+  .launchpad-guide-copy { font-size: 10px; }
+  .launchpad-object-label { min-width: 0; padding: 6px 8px; }
+  .launchpad-object-label small { display: none; }
+  .launchpad-object-label strong { font-size: 8px; }
+  .launchpad-tower-art { height: 200px; }
+  .launchpad-tower-gantry { width: 58px; height: 174px; }
+  .launchpad-tower-rocket { width: 158px; }
+  .launchpad-tower-deck { width: 180px; }
+  .launchpad-satellite svg { width: 70px; }
+  .launchpad-rail-status span:not(:first-child) { display: none; }
+  .launchpad-rail-actions button { padding: 0 9px; font-size: 8px; }
+}
+@media (orientation: landscape) and (max-height: 600px) {
+  .launchpad-visual-scene { inset: 64px 0 54px; }
+  .launchpad-scene-rail { height: 54px; padding: 7px 10px; }
+  .launchpad-guide { top: 8px; left: 8px; width: 300px; padding: 10px 12px; }
+  .launchpad-guide h2 { margin-top: 4px; font-size: 15px; }
+  .launchpad-guide-copy { font-size: 9px; line-height: 1.35; }
+  .launchpad-guide-footer { margin-top: 8px; }
+  .launchpad-guide-actions button { height: 28px; }
+  .launchpad-tower-art { height: 180px; }
+  .launchpad-tower-gantry { width: 52px; height: 158px; }
+  .launchpad-tower-rocket { width: 146px; }
+  .launchpad-tower-deck { width: 165px; }
+  .launchpad-rocket-art { height: 105px; }
+  .launchpad-satellite { top: 2%; }
+}

--- a/web/components/game/ContentUpdateNotice.module.css
+++ b/web/components/game/ContentUpdateNotice.module.css
@@ -1,0 +1,64 @@
+.scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 91;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(2, 7, 14, 0.58);
+  backdrop-filter: blur(3px);
+}
+
+.notice {
+  width: min(440px, 100%);
+  padding: 18px;
+  border: 1px solid var(--ln-cyan-border);
+  border-radius: 8px;
+  background: rgba(4, 12, 23, 0.97);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.48), 0 0 24px rgba(79, 195, 247, 0.1);
+  color: var(--ln-text);
+}
+
+.message {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font: 600 12px/1.65 var(--ln-font-mono);
+  letter-spacing: 0.025em;
+  color: var(--ln-text);
+}
+
+.accent { color: var(--ln-cyan); }
+.muted { color: var(--ln-text-muted); }
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.action {
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid var(--ln-hairline);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--ln-text-muted);
+  font: 800 10px var(--ln-font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.primary {
+  border-color: var(--ln-cyan-border);
+  background: var(--ln-cyan-soft);
+  color: var(--ln-cyan);
+}
+
+@media (max-width: 520px) {
+  .scrim { align-items: end; padding: 12px 12px 70px; }
+  .notice { padding: 15px; }
+  .message { font-size: 11px; }
+}

--- a/web/components/game/ContentUpdateNotice.tsx
+++ b/web/components/game/ContentUpdateNotice.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { Player, Screen } from '@/lib/game-types'
+import {
+  CONTENT_UPDATE_FLAG,
+  contentUpdateTargeting,
+  parseContentUpdatePayload,
+  type ContentUpdate,
+} from '@/lib/content-updates'
+import { initPostHog, posthog } from '@/lib/posthog'
+import styles from './ContentUpdateNotice.module.css'
+
+const SEEN_KEY_PREFIX = 'landnam-content-update-seen:'
+
+interface ContentUpdateNoticeProps {
+  player: Player
+  blocked?: boolean
+  onNavigate: (screen: Screen) => void
+}
+
+export default function ContentUpdateNotice({ player, blocked = false, onNavigate }: ContentUpdateNoticeProps) {
+  const [update, setUpdate] = useState<ContentUpdate | null>(null)
+  const targeting = useMemo(() => contentUpdateTargeting(player), [player])
+  const targetingKey = JSON.stringify(targeting)
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return
+    initPostHog()
+
+    const evaluate = () => {
+      if (!posthog.isFeatureEnabled(CONTENT_UPDATE_FLAG)) {
+        setUpdate(null)
+        return
+      }
+      const next = parseContentUpdatePayload(posthog.getFeatureFlagPayload(CONTENT_UPDATE_FLAG))
+      if (!next || localStorage.getItem(`${SEEN_KEY_PREFIX}${next.id}`)) {
+        setUpdate(null)
+        return
+      }
+      setUpdate(next)
+    }
+
+    const unsubscribe = posthog.onFeatureFlags(evaluate)
+    posthog.setPersonProperties(targeting)
+    posthog.setPersonPropertiesForFlags(targeting, true)
+    evaluate()
+    return unsubscribe
+  }, [targeting, targetingKey])
+
+  useEffect(() => {
+    if (!update || blocked) return
+    posthog.capture('content update shown', {
+      update_id: update.id,
+      playstyle: targeting.landnam_playstyle,
+      progression_stage: targeting.landnam_progression_stage,
+    })
+  }, [blocked, targeting.landnam_playstyle, targeting.landnam_progression_stage, update])
+
+  if (!update || blocked) return null
+
+  const dismiss = (event: 'content update dismissed' | 'content update opened') => {
+    localStorage.setItem(`${SEEN_KEY_PREFIX}${update.id}`, new Date().toISOString())
+    posthog.capture(event, {
+      update_id: update.id,
+      playstyle: targeting.landnam_playstyle,
+      progression_stage: targeting.landnam_progression_stage,
+    })
+    setUpdate(null)
+  }
+
+  return (
+    <div className={styles.scrim} data-testid="content-update-notice">
+      <section className={styles.notice} role="dialog" aria-modal="true" aria-labelledby="content-update-title">
+        <pre className={styles.message}>
+          <span className={styles.accent}>+-- NEW CONTENT --------------------------------+</span>{'\n'}
+          <span id="content-update-title">| {update.headline}</span>{'\n'}
+          <span className={styles.accent}>+-- MISSIONS -----------------------------------+</span>{'\n'}
+          {update.missions.map(mission => <span key={mission}>| &gt; {mission}{'\n'}</span>)}
+          <span className={styles.accent}>+-- YOUR PROGRAM -------------------------------+</span>{'\n'}
+          <span className={styles.muted}>| {update.impact}</span>{'\n'}
+          <span className={styles.accent}>+------------------------------------------------+</span>
+        </pre>
+        <div className={styles.actions}>
+          <button className={styles.action} type="button" onClick={() => dismiss('content update dismissed')}>Dismiss</button>
+          {update.ctaScreen && (
+            <button
+              className={`${styles.action} ${styles.primary}`}
+              type="button"
+              onClick={() => {
+                const destination = update.ctaScreen!
+                dismiss('content update opened')
+                onNavigate(destination)
+              }}
+            >
+              {update.ctaLabel ?? 'Open'}
+            </button>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/web/components/game/GameApp.tsx
+++ b/web/components/game/GameApp.tsx
@@ -14,6 +14,7 @@ import BottomTabBar from '@/components/layout/BottomTabBar'
 import BackendStatus from '@/components/game/BackendStatus'
 import LandnamSyncStatus from '@/components/game/LandnamSyncStatus'
 import { PushOptIn } from '@/components/game/PushOptIn'
+import ContentUpdateNotice from '@/components/game/ContentUpdateNotice'
 import FeedbackButton from '@/components/ui/FeedbackButton'
 import SurveySheet from '@/components/ui/SurveySheet'
 import ToastLayer from '@/components/ui/ToastLayer'
@@ -21,6 +22,7 @@ import { initPostHog } from '@/lib/posthog'
 import DevShortcuts from '@/components/dev/DevShortcuts'
 import AuthGateSheet from '@/components/game/AuthGateSheet'
 import SettingsSheet from '@/components/game/SettingsSheet'
+import SettingsButton from '@/components/game/SettingsButton'
 import TerritoryClaimPopup from '@/components/game/TerritoryClaimPopup'
 import { UI_ZONES } from '@/lib/ui-zones'
 
@@ -162,14 +164,11 @@ function GameCanvas() {
       <div className="portrait-canvas">
         <BackendStatus />
         <LandnamSyncStatus />
-        {/* zIndex 6 keeps PushOptIn below ProgressionCard (8). At 12 it sat
-            above the progression cards and, once its label wrapped, covered the
-            first one — the Skill Tree button stopped responding to taps. It is
-            already *behind* the top HUD (18), which is why only the first few
-            characters ever show; that placement collision is tracked separately
-            and is a design call, not fixed here. */}
+        {/* Mission alerts have a reserved desktop slot to the left of the
+            horizontal resource HUD. They are hidden at compact widths rather
+            than wrapping over progression controls. */}
         {game.player.freeOperations && game.screen === 'hub' && (
-          <div data-ui-zone={UI_ZONES.ambientPrompt} style={{ position: 'absolute', top: 12, right: 12, zIndex: 6 }}>
+          <div data-ui-zone={UI_ZONES.ambientPrompt} className="hub-push-opt-in">
             <PushOptIn userId={game.authUserId ?? undefined} />
           </div>
         )}
@@ -177,24 +176,7 @@ function GameCanvas() {
             gear. Small corner affordance so removing that rail doesn't strand
             it. Hub only, so it never sits over gameplay chrome. */}
         {game.screen === 'hub' && (
-          <button
-            data-testid="settings-button"
-            aria-label="Settings"
-            onClick={() => setSettingsOpen(true)}
-            style={{
-              position: 'absolute', left: 12, bottom: 56, zIndex: 22,
-              width: 34, height: 34, borderRadius: 999, cursor: 'pointer',
-              display: 'grid', placeItems: 'center', padding: 0,
-              background: 'var(--hub-panel, #080d18)',
-              border: '1.5px solid var(--hub-outline, rgba(255,255,255,0.55))',
-              color: 'var(--hub-cyan, #6cd4ff)',
-            }}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
-            </svg>
-          </button>
+          <SettingsButton onClick={() => setSettingsOpen(true)} />
         )}
         <DevShortcuts />
         <div className="game-screen-area">
@@ -214,6 +196,13 @@ function GameCanvas() {
           <MissionTicker player={game.player} screen={game.screen} onResume={game.go} />
         )}
         {showFeedback && <FeedbackButton />}
+        {['hub', 'missions', 'launchpad'].includes(game.screen) && (
+          <ContentUpdateNotice
+            player={game.player}
+            blocked={surveyBlocked || game.upgradePromptOpen || game.authGateOpen}
+            onNavigate={screen => game.go(screen)}
+          />
+        )}
         <SurveySheet blockWhile={surveyBlocked} />
         {showNav && <BottomTabBar current={currentNav} onNav={goFromNav} />}
 

--- a/web/components/game/GameScreenRouter.tsx
+++ b/web/components/game/GameScreenRouter.tsx
@@ -320,6 +320,7 @@ export function ScreenContent({
           }}
           onViewContracts={() => game.goToMissions()}
           onOpenHangar={() => game.go('hangar')}
+          onBuildMonitoring={() => game.go('build')}
           missionsDone={game.player.missionsDone}
           freeOperations={game.player.freeOperations}
           catalog={game.catalog}

--- a/web/components/game/ProgressionCard.tsx
+++ b/web/components/game/ProgressionCard.tsx
@@ -205,7 +205,7 @@ export default function ProgressionCard({ player, onGoBuilding, onNav, top = 132
     // Hub root is `overflow: hidden`, so without an internal scroll
     // affordance here, cards below the fold were silently unreachable
     // rather than just visually tight (STS-612).
-    <div style={{
+    <div className="hub-progression-stack" style={{
       position: 'absolute', right: 14, top, bottom: TUTORIAL_RAIL.BOTTOM_PILL_Y, zIndex: 8,
       width: 'calc(100% - 28px)', maxWidth: 280, pointerEvents: 'auto',
       display: 'flex', flexDirection: 'column', gap: 6,

--- a/web/components/game/SettingsButton.module.css
+++ b/web/components/game/SettingsButton.module.css
@@ -1,0 +1,23 @@
+.button {
+  position: absolute;
+  left: 12px;
+  bottom: 56px;
+  z-index: 22;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  place-items: center;
+  color: var(--hub-cyan, #6cd4ff);
+  cursor: pointer;
+  background: var(--hub-panel, #080d18);
+  border: 1.5px solid var(--hub-outline, rgba(255, 255, 255, 0.55));
+  border-radius: 999px;
+}
+
+.button:hover,
+.button:focus-visible {
+  color: #e6efff;
+  border-color: var(--hub-cyan, #6cd4ff);
+  box-shadow: 0 0 16px rgba(108, 212, 255, 0.22);
+}

--- a/web/components/game/SettingsButton.tsx
+++ b/web/components/game/SettingsButton.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import styles from './SettingsButton.module.css'
+
+export default function SettingsButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={styles.button}
+      data-testid="settings-button"
+      aria-label="Settings"
+      onClick={onClick}
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
+      </svg>
+    </button>
+  )
+}

--- a/web/components/game/screens/BuildPlaceScreen.tsx
+++ b/web/components/game/screens/BuildPlaceScreen.tsx
@@ -16,6 +16,7 @@ import HubPixiCanvas from '@/components/game/hub/HubPixiCanvas'
 import ErrorBoundary from '@/components/ui/ErrorBoundary'
 import type { HubBuildingDef } from '@/lib/pixi/hubScene'
 import { formatCurrency } from '@/lib/format'
+import { FEATURE_FLAGS } from '@/lib/featureFlags'
 
 // Instantiated from the build-plot prefab rather than written out by hand.
 // This same list previously existed in four places (both hub scene files and
@@ -76,7 +77,9 @@ export default function BuildPlaceScreen({ onPlaced, onBack, hasCoach, player }:
       .catch(() => {})
   }, [])
 
-  const catalog = STRUCTURES.filter(s => s.id !== 'garage')
+  const catalog = STRUCTURES.filter(s =>
+    s.id !== 'garage' && (FEATURE_FLAGS.scanStation || s.id !== 'scan-station')
+  )
   const sel = catalog.find(c => c.id === picked) ?? catalog[0]
   const sortedEntities = plotEntities.slice().sort((a, b) => {
     const ai = readComponentNumber(a, 'BuildPlot', 'index', 0)

--- a/web/components/game/screens/HubScreen.tsx
+++ b/web/components/game/screens/HubScreen.tsx
@@ -17,7 +17,7 @@ import { Building, EmptyPlot } from '@/components/game/hub/Building'
 import type { BuildingCallout } from '@/components/game/hub/Building'
 import HubPixiCanvas from '@/components/game/hub/HubPixiCanvas'
 import ErrorBoundary from '@/components/ui/ErrorBoundary'
-import { TUTORIAL_CONTENT_TOP } from '@/lib/tutorial-layout'
+import { TUTORIAL_CONTENT_TOP, TUTORIAL_RAIL } from '@/lib/tutorial-layout'
 import { FREE_OPS_START_MISSIONS_DONE } from '@/lib/data/mission-generator'
 import { LAUNCHPAD_UPGRADE_COST, type SubsurfaceRoomId } from '@/lib/data'
 import { formatCurrency } from '@/lib/format'
@@ -151,6 +151,7 @@ export default function HubScreen({ player, hasCoach, onGoBuilding, onNav, onUpg
     ...placementPlots,
     ...(legacyPlaced('launchpad') ? { launchpad: 0 } : {}),
   }
+  if (!FEATURE_FLAGS.scanStation) delete effectivePlots['scan-station']
 
   useEffect(() => {
     Scene.load('/game/scenes/hub.scene.json')
@@ -447,14 +448,19 @@ export default function HubScreen({ player, hasCoach, onGoBuilding, onNav, onUpg
         </div>
         <span style={{ flex: 1 }} />
         <div style={{ pointerEvents: 'auto' }}>
-          <HUDStrip player={player} showStash onJobsClick={() => onNav('missions')} />
+          <HUDStrip player={player} onJobsClick={() => onNav('missions')} />
         </div>
       </div>
 
       {/* Progression card — hidden when tutorial coach is active */}
       {(!hasCoach || !!player.activeMission || !!player.pendingLaunch) && !subsurface && (
         <>
-          <ProgressionCard player={player} onGoBuilding={onGoBuilding} onNav={onNav} top={TUTORIAL_CONTENT_TOP} />
+          <ProgressionCard
+            player={player}
+            onGoBuilding={onGoBuilding}
+            onNav={onNav}
+            top={hasCoach ? TUTORIAL_CONTENT_TOP : TUTORIAL_RAIL.TOP_CHROME_HEIGHT + 8}
+          />
           {showTutorialComplete && (
             <TutorialCompleteSheet onDone={dismissTutorialComplete} />
           )}
@@ -480,8 +486,8 @@ export default function HubScreen({ player, hasCoach, onGoBuilding, onNav, onUpg
           Ops for the whole guided-ops window meant those buttons stayed
           unreachable well past the tutorial (bug reported 2026-07-31). */}
       {(!hasCoach || player.missionsDone > 0) && (
-        <div style={{
-          position: 'absolute', left: 0, right: 0, bottom: 110, zIndex: 20,
+        <div className="hub-action-rail" style={{
+          position: 'absolute', left: 0, right: 0, zIndex: 20,
           display: 'flex', justifyContent: 'center', gap: 8, flexWrap: 'wrap',
           padding: '0 12px',
         }}>

--- a/web/components/game/screens/LaunchpadScreen.test.tsx
+++ b/web/components/game/screens/LaunchpadScreen.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import LaunchpadScreen from './LaunchpadScreen'
+import { STATIC_CATALOG } from '@/lib/catalog'
+import { DEFAULT_STATE } from '@/lib/game-state'
+
+function renderLaunchpad(satelliteMonitoringBuilt: boolean): string {
+  return renderToStaticMarkup(
+    <LaunchpadScreen
+      onBack={() => undefined}
+      onPick={() => undefined}
+      onViewContracts={() => undefined}
+      onOpenHangar={() => undefined}
+      onBuildMonitoring={() => undefined}
+      missionsDone={4}
+      freeOperations
+      catalog={STATIC_CATALOG}
+      player={{ ...DEFAULT_STATE.player, missionsDone: 4, freeOperations: true, satelliteMonitoringBuilt }}
+      francs={DEFAULT_STATE.player.francs}
+    />
+  )
+}
+
+describe('LaunchpadScreen infrastructure hierarchy', () => {
+  it('renders owned infrastructure as a visual scene with an actionable monitoring build', () => {
+    const markup = renderLaunchpad(false)
+    expect(markup).toContain('data-testid="launchpad-monitoring-structure"')
+    expect(markup).toContain('data-testid="launchpad-satellite-orbit"')
+    expect(markup).toContain('data-testid="launchpad-rocket-fleet"')
+    expect(markup).toContain('data-testid="launchpad-build-monitoring-btn"')
+    expect(markup).toContain('data-testid="launchpad-guide-open"')
+    expect(markup).toContain('BUILD MONITORING STATION')
+    expect(markup).toContain('class="game-screen theme-deep ln-scene-launchpad"')
+    expect(markup).not.toContain('launchpad-command-grid')
+    expect(markup).not.toMatch(/<p(?:\s|>)/)
+  })
+
+  it('shows the built state without a duplicate build CTA', () => {
+    const markup = renderLaunchpad(true)
+    expect(markup).toContain('S.M.S. · ONLINE')
+    expect(markup).not.toContain('data-testid="launchpad-build-monitoring-btn"')
+  })
+})

--- a/web/components/game/screens/LaunchpadScreen.tsx
+++ b/web/components/game/screens/LaunchpadScreen.tsx
@@ -1,13 +1,10 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import TopBar from '@/components/ui/TopBar'
-import { PrimaryBtn, GhostBtn } from '@/components/ui/Button'
-import MissionCard from '@/components/game/MissionCard'
-import { ACADEMY_INTRO_MISSION_ID, compatibleTargetsFor, missionTypePrimer, partitionByOwner } from '@/lib/data'
+import { ACADEMY_INTRO_MISSION_ID, partitionByOwner } from '@/lib/data'
 import { ROCKET_MODELS } from '@/lib/data/rockets'
 import { SATELLITE_MODELS } from '@/lib/data/satellites'
-import { formatCurrency } from '@/lib/format'
 import type { Catalog } from '@/lib/catalog'
 import type { Player } from '@/lib/game-types'
 import { academyAffinityUnlocked } from '@/lib/systems/AcademySystem'
@@ -15,10 +12,10 @@ import { UI_ZONES } from '@/lib/ui-zones'
 
 interface LaunchpadScreenProps {
   onBack: () => void
-  /** Commits to a mission — same click-to-commit contract as the Mission Board. */
   onPick: (id: string) => void
   onViewContracts: () => void
   onOpenHangar: () => void
+  onBuildMonitoring: () => void
   missionsDone: number
   freeOperations: boolean
   catalog: Catalog
@@ -26,250 +23,182 @@ interface LaunchpadScreenProps {
   francs?: number
 }
 
-const infoCardStyle: React.CSSProperties = {
-  padding: 16, borderRadius: 12,
-  border: '1px solid var(--ln-hairline)',
-  background: 'var(--ln-panel)',
-  display: 'flex', flexDirection: 'column', gap: 10,
+const LAUNCHPAD_GUIDE_KEY = 'landnam-launchpad-guide-v1'
+
+function SatelliteGlyph() {
+  return (
+    <svg viewBox="0 0 150 74" aria-hidden="true">
+      <g fill="none" stroke="currentColor" strokeWidth="3">
+        <rect x="57" y="20" width="36" height="34" rx="4" />
+        <path d="M63 20l8-11h8l8 11M75 54v12M66 66h18" />
+        <path d="M57 27H9v22h48M93 27h48v22H93M19 27v22M31 27v22M43 27v22M107 27v22M119 27v22M131 27v22" />
+      </g>
+    </svg>
+  )
 }
 
-const sectionLabelStyle: React.CSSProperties = {
-  fontFamily: 'var(--ln-font-display)', fontSize: 11, letterSpacing: '0.08em',
-  textTransform: 'uppercase', color: 'var(--ln-text-muted)',
+function HangarGlyph() {
+  return <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 21V8l3-4h10l3 4v13M4 9h16M8 21v-7h8v7" /></svg>
 }
 
-/**
- * The launchpad's own screen, and the first thing a player sees when they tap
- * the launchpad — their own program before anybody else's order.
- *
- * Tapping the launchpad used to drop straight onto the Mission Board, which is
- * a wall of client requests: the player's read was "this pad exists to serve
- * other people". Own-initiative work (launching your own satellite, a
- * self-directed run, raising your own infrastructure) had no home of its own.
- * This screen is that home; the Mission Board is one press away and unchanged.
- *
- * The own/client split is `isOwnProgramMission` via `partitionByOwner` — the
- * same authority the Mission Board's grouping uses, so the two surfaces can
- * never disagree about whose job something is.
- */
+function MissionGlyph() {
+  return <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="3" width="16" height="18" rx="2" /><path d="M8 8h8M8 12h8M8 16h5" /></svg>
+}
+
+function GuideGlyph() {
+  return <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M9.8 9a2.3 2.3 0 1 1 3.1 2.2c-.9.4-.9 1.1-.9 1.8M12 17h.01" /></svg>
+}
+
 export default function LaunchpadScreen({
-  onBack, onPick, onViewContracts, onOpenHangar, missionsDone, freeOperations, catalog, player, francs,
+  onBack, onPick, onViewContracts, onOpenHangar, onBuildMonitoring, missionsDone, freeOperations, catalog, player, francs,
 }: LaunchpadScreenProps) {
-  const { missions: MISSIONS, clients: CLIENTS, minerals: MINERAL_META, targets } = catalog
+  const [guideStep, setGuideStep] = useState<number | null>(null)
+  const fleet = ROCKET_MODELS.map(model => ({ model, unlocked: missionsDone >= model.missionsRequired && !model.locked }))
+  const unlockedFleet = fleet.filter(item => item.unlocked)
+  const launchedSatellites = player.transitSatelliteLaunchedAt ? SATELLITE_MODELS.length : 0
+  const { own } = partitionByOwner(catalog.missions, mission => mission)
   const sequence = missionsDone + 1
-
-  // Defensive, not the normal path: GameScreenRouter already resolves an
-  // active/pending build to the transit/fab screen before the player ever
-  // lands here. Kept so a rocket mid-build is never silently hidden if this
-  // screen is ever reached another way.
-  const rocketInProgress = player.activeMission
-    ? { label: player.activeMission.label, status: 'In flight' }
-    : player.pendingLaunch
-      ? { label: 'Rocket', status: 'Fabrication in progress' }
-      : null
-
-  const fleet = ROCKET_MODELS.map(m => ({
-    model: m,
-    unlocked: missionsDone >= m.missionsRequired && !m.locked,
-  }))
-
-  // Satellites unlock off the Satellite Monitoring Station structure and are
-  // launched once — not the rocket fleet's missionsRequired axis.
-  const satellites = SATELLITE_MODELS.map(m => {
-    const launched = !!player.transitSatelliteLaunchedAt
-    const available = !!player.satelliteMonitoringBuilt && !launched
-    return {
-      model: m,
-      launched,
-      available,
-    }
+  const operations = own.filter(mission => freeOperations || mission.sequence === sequence)
+  const nextOperation = operations.find(mission => {
+    if (mission.id !== ACADEMY_INTRO_MISSION_ID) return true
+    const academyUnlocked = academyAffinityUnlocked(player) || !!player.academyResearched || player.placed.includes('astronaut-academy')
+    const academyCompleted = player.placed.includes('astronaut-academy') && (player.crew ?? []).some(member =>
+      member.crewClass === 'astronaut' && member.selfTrained && member.specialisations.length > 0,
+    )
+    return academyUnlocked && !academyCompleted
   })
+  const guideSteps = [
+    {
+      label: '01 · GROUND SYSTEM',
+      title: player.satelliteMonitoringBuilt ? 'Monitoring online' : 'Build the monitoring station',
+      body: player.satelliteMonitoringBuilt
+        ? 'This station receives telescope downlinks and turns them into science work.'
+        : 'You need this before your first transit telescope can operate.',
+      target: 'station',
+    },
+    {
+      label: '02 · LAUNCHPAD',
+      title: 'Launch from here',
+      body: 'Assigned vehicles move from the hangar to this pad before flight.',
+      target: 'tower',
+    },
+    {
+      label: '03 · ROCKET FLEET',
+      title: 'Prepare your vehicles',
+      body: 'Open the hangar to inspect unlocked rockets and fit upgrades.',
+      target: 'rocket',
+    },
+    {
+      label: '04 · YOUR PROGRAM',
+      title: 'Choose what flies next',
+      body: 'Operations use your own assets. Contracts fund their expansion.',
+      target: 'satellite',
+    },
+  ] as const
+  const guide = guideStep === null ? null : guideSteps[guideStep]
 
-  // Own-program work carries no client, so none of the board's client gating
-  // applies: no daily pool slot, no cooldown, no affinity tier. During
-  // onboarding the sequence gate still holds; in Free Ops everything the
-  // player owns is theirs to fly whenever they like.
-  const { own } = partitionByOwner(MISSIONS, m => m)
-  const launchables = own.filter(m => freeOperations || m.sequence === sequence)
+  useEffect(() => {
+    if (!window.localStorage.getItem(LAUNCHPAD_GUIDE_KEY)) setGuideStep(0)
+  }, [])
 
-  const cards = launchables.map(m => ({
-    mission: m,
-    client: m.client ? CLIENTS[m.client] ?? null : null,
-    targetCount: compatibleTargetsFor(m, targets).length,
-    primer: missionTypePrimer(m),
-  }))
+  const closeGuide = () => {
+    window.localStorage.setItem(LAUNCHPAD_GUIDE_KEY, 'complete')
+    setGuideStep(null)
+  }
+
+  const isGuided = (target: (typeof guideSteps)[number]['target']) => guide?.target === target
 
   return (
-    <div
-      className="ln-scene-launchpad"
-      style={{ width: '100%', height: '100%', position: 'relative' }}
-    >
-      <TopBar
-        eyebrow="EARTH BASE · LAUNCHPAD"
-        title="Your Program"
-        onBack={onBack}
-        solid
-        francs={francs}
-      />
+    <div className="game-screen theme-deep ln-scene-launchpad">
+      <TopBar eyebrow="EARTH BASE · LAUNCHPAD" title="Your Program" onBack={onBack} solid francs={francs} />
 
-      <div
-        data-ui-zone={UI_ZONES.screenContent}
-        style={{ position: 'absolute', inset: 0, paddingTop: 72, paddingBottom: 96, overflowY: 'auto' }}
-      >
-        <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 16 }}>
-          {rocketInProgress && (
-            <div style={{ ...infoCardStyle, borderColor: 'var(--ln-cyan)' }} data-testid="launchpad-rocket-in-progress">
-              <div style={sectionLabelStyle}>Rocket In Progress</div>
-              <div style={{ fontFamily: 'var(--ln-font-display)', fontSize: 16, color: 'var(--ln-text)' }}>
-                {rocketInProgress.label}
-              </div>
-              <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 12, color: 'var(--ln-cyan)' }}>
-                {rocketInProgress.status}
-              </div>
-            </div>
-          )}
+      <main data-ui-zone={UI_ZONES.screenContent} className="launchpad-visual-scene">
+        <div className="launchpad-stars" />
+        <div className="launchpad-orbit-line" />
 
-          <div className="ln-instrument-card" data-testid="launchpad-status-card">
-            <div className="ln-instrument-label">Launchpad Status</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-              <div className="ln-instrument-value">
-                {player.launchpadUpgraded ? 'Upgraded Pad' : 'Standard Pad'}
-              </div>
-              {!player.launchpadUpgraded && (
-                <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 11, color: 'var(--scene-card-muted)' }}>
-                  Upgrade from Edit · Build on the Hub
-                </div>
-              )}
-            </div>
-          </div>
-
-          <div className="ln-instrument-card" data-testid="launchpad-fleet-card">
-            <div className="ln-instrument-label">Fleet</div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {fleet.map(({ model, unlocked }) => (
-                <div
-                  key={model.id}
-                  style={{
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                    opacity: unlocked ? 1 : 0.45,
-                  }}
-                >
-                  <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 13, color: 'var(--scene-card-text)' }}>
-                    {model.name}
-                  </div>
-                  <div style={{ fontFamily: 'var(--ln-font-mono)', fontSize: 11, color: 'var(--scene-card-muted)' }}>
-                    {unlocked
-                      ? model.costFrancs > 0 ? formatCurrency(model.costFrancs, { compact: true }) : 'Free'
-                      : model.unlockHint}
-                  </div>
-                </div>
-              ))}
-            </div>
-            <GhostBtn testId="launchpad-open-hangar-btn" onClick={onOpenHangar}>
-              Open Hangar →
-            </GhostBtn>
-          </div>
-
-          <div className="ln-instrument-card" data-testid="launchpad-satellites-card">
-            <div className="ln-instrument-label">Satellites</div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {satellites.map(({ model, launched, available }) => (
-                <div
-                  key={model.id}
-                  style={{
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                    opacity: available || launched ? 1 : 0.45,
-                  }}
-                >
-                  <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 13, color: 'var(--scene-card-text)' }}>
-                    {model.name}
-                  </div>
-                  <div style={{ fontFamily: 'var(--ln-font-mono)', fontSize: 11, color: 'var(--scene-card-muted)' }}>
-                    {launched ? 'DEPLOYED' : available ? 'READY TO LAUNCH' : model.unlockHint.toUpperCase()}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div style={{
-            fontFamily: 'var(--ln-font-body)', fontSize: 12, lineHeight: 1.5,
-            color: 'var(--ln-text-muted)',
-          }}>
-            Work you launch on your own initiative — your satellites, your
-            infrastructure, your own mining runs. Nobody ordered these and
-            nobody else owns what they leave behind.
-          </div>
-
-          {cards.length > 0 ? (
-            <div
-              data-testid="launchpad-own-program-list"
-              style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
-            >
-              {cards.map(c => {
-                const isAcademyTask = c.mission.id === ACADEMY_INTRO_MISSION_ID
-                const academyUnlocked = academyAffinityUnlocked(player)
-                  || !!player.academyResearched
-                  || player.placed.includes('astronaut-academy')
-                const academyCompleted = isAcademyTask
-                  && player.placed.includes('astronaut-academy')
-                  && (player.crew ?? []).some(member =>
-                    member.crewClass === 'astronaut'
-                    && member.selfTrained
-                    && member.specialisations.length > 0,
-                  )
-                const unlocked = !isAcademyTask || (academyUnlocked && !academyCompleted)
-                return (
-                  <MissionCard
-                    key={c.mission.id}
-                    mission={c.mission}
-                    client={c.client}
-                    mineralMeta={MINERAL_META}
-                    targetCount={c.targetCount}
-                    displayPayout={c.mission.payout.francs}
-                    unlocked={unlocked}
-                    isStoryMission={c.mission.tag === 'STORY' && !c.mission.deliveryTargetId}
-                    cardState={academyCompleted ? 'completed' : unlocked ? 'available' : 'locked'}
-                    lockedDetail={isAcademyTask && !academyCompleted ? 'Reach L2 affinity with two clients' : undefined}
-                    onPick={() => onPick(c.mission.id)}
-                  />
-                )
-              })}
-            </div>
-          ) : (
-            <div
-              data-testid="launchpad-own-program-empty"
-              style={{
-                padding: 24, borderRadius: 12,
-                border: '1px solid var(--ln-hairline)',
-                background: 'var(--ln-panel)',
-                fontFamily: 'var(--ln-font-body)', fontSize: 12, lineHeight: 1.5,
-                color: 'var(--ln-text-muted)',
-              }}
-            >
-              Nothing of your own is ready to fly yet. Client contracts are what
-              pay for the program that gets you there.
-            </div>
-          )}
+        <div className={`launchpad-satellite ${isGuided('satellite') ? 'is-guided' : ''}`} data-testid="launchpad-satellite-orbit">
+          <SatelliteGlyph />
+          <div><strong>{launchedSatellites}/{SATELLITE_MODELS.length}</strong><span>ORBIT</span></div>
         </div>
-      </div>
 
-      <div
-        className="sticky-actions"
-        data-ui-zone={UI_ZONES.bottomActions}
-        data-coach-id="launchpad-view-contracts"
-        style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: 16 }}
-      >
-        {cards.length > 0 ? (
-          <GhostBtn testId="launchpad-view-contracts-btn" onClick={onViewContracts}>
-            View All Contracts →
-          </GhostBtn>
-        ) : (
-          <PrimaryBtn testId="launchpad-view-contracts-btn" onClick={onViewContracts}>
-            View All Contracts →
-          </PrimaryBtn>
+        <button
+          type="button"
+          className={`launchpad-scene-object launchpad-station ${player.satelliteMonitoringBuilt ? 'is-built' : 'is-blueprint'} ${isGuided('station') ? 'is-guided' : ''}`}
+          data-testid="launchpad-monitoring-structure"
+          onClick={player.satelliteMonitoringBuilt ? undefined : onBuildMonitoring}
+        >
+          <span className="launchpad-object-art">
+            <img src="/game/assets/hub/sat_station.png" alt="" />
+            {!player.satelliteMonitoringBuilt && <i className="launchpad-build-plus">+</i>}
+          </span>
+          <span className="launchpad-object-label">
+            <small>GROUND SYSTEM</small>
+            <strong>{player.satelliteMonitoringBuilt ? 'S.M.S. · ONLINE' : 'BUILD MONITORING STATION'}</strong>
+          </span>
+        </button>
+
+        <div className={`launchpad-scene-object launchpad-tower ${isGuided('tower') ? 'is-guided' : ''}`} data-testid="launchpad-status-card">
+          <span className="launchpad-tower-art">
+            <img className="launchpad-tower-gantry" src="/game/assets/hub/pad_gantry_frame.png" alt="" />
+            <img className="launchpad-tower-rocket" src="/game/assets/ships/ship_sr1.png" alt="" />
+            <img className="launchpad-tower-deck" src="/game/assets/hub/pad_deck.png" alt="" />
+          </span>
+          <span className="launchpad-object-label launchpad-object-label--center">
+            <small>LAUNCHPAD</small>
+            <strong>{player.activeMission ? 'IN FLIGHT' : player.pendingLaunch ? 'ON PAD' : 'READY'}</strong>
+          </span>
+        </div>
+
+        <button type="button" className={`launchpad-scene-object launchpad-rocket ${isGuided('rocket') ? 'is-guided' : ''}`} data-testid="launchpad-rocket-fleet" onClick={onOpenHangar}>
+          <span className="launchpad-rocket-art">
+            <img src="/game/assets/ships/ship_sr1.png" alt="" />
+            <i className="launchpad-rocket-glow" />
+          </span>
+          <span className="launchpad-object-label">
+            <small>ROCKET FLEET · {unlockedFleet.length}</small>
+            <strong>{unlockedFleet[0]?.model.name ?? 'NO VEHICLE'} · HANGAR</strong>
+          </span>
+        </button>
+
+        {guide && guideStep !== null && (
+          <aside className="launchpad-guide" data-testid="launchpad-guide" aria-live="polite" aria-labelledby="launchpad-guide-title">
+            <button className="launchpad-guide-close" data-testid="launchpad-guide-close" onClick={closeGuide} aria-label="Close Launchpad guide">×</button>
+            <span className="launchpad-guide-kicker">{guide.label}</span>
+            <h2 id="launchpad-guide-title">{guide.title}</h2>
+            <span className="launchpad-guide-copy">{guide.body}</span>
+            <div className="launchpad-guide-footer">
+              <div className="launchpad-guide-progress" aria-label={`Guide step ${guideStep + 1} of ${guideSteps.length}`}>
+                {guideSteps.map((step, index) => <i key={step.target} className={index === guideStep ? 'is-current' : ''} />)}
+              </div>
+              <div className="launchpad-guide-actions">
+                {guideStep > 0 && <button data-testid="launchpad-guide-back" onClick={() => setGuideStep(guideStep - 1)}>BACK</button>}
+                <button className="is-primary" data-testid="launchpad-guide-next" onClick={() => guideStep === guideSteps.length - 1 ? closeGuide() : setGuideStep(guideStep + 1)}>
+                  {guideStep === guideSteps.length - 1 ? 'DONE' : 'NEXT'}
+                </button>
+              </div>
+            </div>
+          </aside>
         )}
-      </div>
+
+        <div className="launchpad-ground-line" />
+      </main>
+
+      <footer className="launchpad-scene-rail" data-ui-zone={UI_ZONES.bottomActions}>
+        <div className="launchpad-rail-status">
+          <span><i /> PAD {player.activeMission ? 'ACTIVE' : 'READY'}</span>
+          <span>{unlockedFleet.length} ROCKETS</span>
+          <span>{launchedSatellites}/{SATELLITE_MODELS.length} SAT</span>
+        </div>
+        <div className="launchpad-rail-actions">
+          <button data-testid="launchpad-guide-open" onClick={() => setGuideStep(0)}><GuideGlyph /> GUIDE</button>
+          {!player.satelliteMonitoringBuilt && (
+            <button className="is-primary" data-testid="launchpad-build-monitoring-btn" onClick={onBuildMonitoring}>BUILD STATION</button>
+          )}
+          <button data-testid="launchpad-open-hangar-btn" onClick={onOpenHangar}><HangarGlyph /> HANGAR</button>
+          {nextOperation && <button data-testid="launchpad-program-operation-btn" onClick={() => onPick(nextOperation.id)}><MissionGlyph /> OPS {operations.length}</button>}
+          <button data-testid="launchpad-view-contracts-btn" onClick={onViewContracts}><MissionGlyph /> CONTRACTS</button>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/web/components/ui/HUDStrip.tsx
+++ b/web/components/ui/HUDStrip.tsx
@@ -70,7 +70,7 @@ function Chip({ glyph, children, accent = 'var(--hub-cyan)', onClick, testId }: 
 
 export default function HUDStrip({ player, showStash = false, onJobsClick }: HUDStripProps) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'flex-end' }}>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center', justifyContent: 'flex-end' }}>
       <Chip glyph={<FrancGlyph />}>
         <span style={{ fontFamily: 'var(--ln-font-mono)', fontWeight: 700, fontSize: 12, color: '#fff' }}>
           {formatCurrency(player.francs, { compact: true })}

--- a/web/cypress/e2e/visual/sprint-11-hotfix.cy.ts
+++ b/web/cypress/e2e/visual/sprint-11-hotfix.cy.ts
@@ -1,0 +1,200 @@
+import type { GameState } from '@/game-context'
+
+const STORAGE_KEY = 'landnam-game-state-v1'
+
+function stateFor(screen: GameState['screen']): GameState {
+  return {
+    screen,
+    player: {
+      francs: 11_580_000_000,
+      activeMission: null,
+      missionCount: 9,
+      pendingLaunch: false,
+      placed: ['launchpad', 'refinery'],
+      placementPlots: { launchpad: 0, refinery: 1 },
+      controlBuilt: true,
+      missionsDone: 4,
+      skillPoints: 3,
+      unlockedSkillNodes: [],
+      freeOperations: true,
+      clientMissions: {},
+      clientStreaks: {},
+      clientCooldowns: {},
+      researchAnnotations: 0,
+      refineryBuilt: true,
+      refineryUnlocked: true,
+      refineryUnlockNotified: true,
+      refineryQueue: [],
+      refinedGoods: {},
+      launchpadUpgraded: false,
+      loanDebt: 0,
+      loanOffered: false,
+      seen_planets: [],
+      roverDeployments: [],
+      clientTerritories: {},
+      satelliteMonitoringBuilt: false,
+      satelliteMonitoringLevel: 0,
+      transitSatelliteLaunchedAt: null,
+      transitSatelliteLevel: 0,
+      tessClassifications: {},
+      stash: { iron: 12, silicon: 5, gold: 2 },
+    },
+    missionId: null,
+    targetId: null,
+    deliveryTargetId: null,
+    rocket: { chassis: 'hull-mk2', propulsion: 'fusion-b2', drill: 'laser-t2' },
+    lastCargo: null,
+    tutorial: false,
+    doneSteps: {},
+    popup: null,
+    menuOpen: false,
+  } as GameState
+}
+
+function visitGame(path: string, screen: GameState['screen']) {
+  cy.visit(path, {
+    onBeforeLoad(win) {
+      win.localStorage.clear()
+      win.localStorage.setItem(STORAGE_KEY, JSON.stringify(stateFor(screen)))
+      win.localStorage.setItem('landnam-guest-credentials', JSON.stringify({
+        email: 'sprint-11-hotfix-invalid@landnam.guest',
+        password: 'GuestPassword123!',
+      }))
+      win.localStorage.setItem('landnam-upgrade-prompt-snooze-until', String(Date.now() + 365 * 24 * 60 * 60 * 1000))
+      win.localStorage.setItem('ln_tutorial_complete_ack', '1')
+      win.localStorage.setItem('landnam-surveys-shown', JSON.stringify([
+        'lnm_first_launch', 'lnm_mining_feel', 'lnm_client_pick',
+        'lnm_mission_friction', 'lnm_progression_feel', 'lnm_end_of_content',
+        'lnm_return_visit', 'lnm_m1_complete', 'lnm_m2_complete', 'lnm_m3_complete',
+        'lnm_satellite_clarity', 'lnm_resume_mission', 'lnm_base_building', 'lnm_rover_clarity',
+      ]))
+    },
+  })
+}
+
+function expectNoOverlap(a: DOMRect, b: DOMRect, label: string) {
+  const overlaps = a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+  expect(overlaps, label).to.eq(false)
+}
+
+function expectBackendsHealthy(attempts = 4): Cypress.Chainable<void> {
+  return cy.request({ url: '/api/backend-health', failOnStatusCode: false }).then(response => {
+    const healthy = response.status === 200
+      && response.body?.ok === true
+      && response.body?.backends?.shared?.ok === true
+      && response.body?.backends?.landnam?.ok === true
+    if (!healthy && attempts > 1) {
+      return cy.wait(500).then(() => expectBackendsHealthy(attempts - 1))
+    }
+    expect(response.status, 'backend health response').to.eq(200)
+    expect(response.body.ok, 'combined backend health').to.eq(true)
+    expect(response.body.backends?.shared?.ok, 'shared PocketBase health').to.eq(true)
+    expect(response.body.backends?.landnam?.ok, 'Landnam PocketBase health').to.eq(true)
+  })
+}
+
+describe('Sprint 11 Launchpad and Earth Base hotfix — live browser QA', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 800)
+    expectBackendsHealthy()
+  })
+
+  it('keeps every essential Launchpad control in one viewport and opens the monitoring build flow', () => {
+    visitGame('/game/launchpad', 'launchpad')
+
+    cy.contains('Your Program', { timeout: 15_000 }).should('be.visible')
+    cy.get('[data-testid="launchpad-monitoring-structure"]').should('be.visible')
+    cy.get('[data-testid="launchpad-satellite-orbit"]').should('be.visible')
+    cy.get('[data-testid="launchpad-rocket-fleet"]').should('be.visible')
+    cy.get('[data-testid="launchpad-build-monitoring-btn"]').should('be.visible')
+    cy.get('[data-testid="launchpad-open-hangar-btn"]').should('be.visible')
+    cy.get('[data-testid="launchpad-view-contracts-btn"]').should('be.visible')
+    cy.get('[data-testid="launchpad-guide-open"]').should('be.visible')
+
+    cy.get('[data-testid="launchpad-guide"]').should('be.visible').and('contain', 'Build the monitoring station')
+    cy.get('[data-testid="launchpad-monitoring-structure"]').should('have.class', 'is-guided')
+    cy.get('[data-testid="launchpad-guide-next"]').click()
+    cy.get('[data-testid="launchpad-guide"]').should('contain', 'Launch from here')
+    cy.get('[data-testid="launchpad-status-card"]').should('have.class', 'is-guided')
+    cy.get('[data-testid="launchpad-guide-next"]').click()
+    cy.get('[data-testid="launchpad-guide"]').should('contain', 'Prepare your vehicles')
+    cy.get('[data-testid="launchpad-rocket-fleet"]').should('have.class', 'is-guided')
+    cy.get('[data-testid="launchpad-guide-next"]').click()
+    cy.get('[data-testid="launchpad-guide"]').should('contain', 'Choose what flies next')
+    cy.get('[data-testid="launchpad-satellite-orbit"]').should('have.class', 'is-guided')
+    cy.get('[data-testid="launchpad-guide-next"]').should('contain', 'DONE').click()
+    cy.get('[data-testid="launchpad-guide"]').should('not.exist')
+    cy.get('[data-testid="launchpad-guide-open"]').click()
+    cy.get('[data-testid="launchpad-guide"]').should('be.visible')
+
+    cy.get('.launchpad-visual-scene').then($scene => {
+      const scene = $scene[0].getBoundingClientRect()
+      cy.get('.launchpad-scene-rail').then($rail => {
+        const rail = $rail[0].getBoundingClientRect()
+        expect(scene.bottom, 'visual scene ends above command rail').to.be.at.most(rail.top + 1)
+      })
+    })
+    cy.window().then(win => {
+      expect(win.document.documentElement.scrollHeight, 'page does not vertically scroll').to.be.at.most(win.innerHeight)
+      const viewport = win.document.querySelector('.launchpad-visual-scene') as HTMLElement
+      expect(viewport.scrollHeight, 'Launchpad scene fits its viewport').to.be.at.most(viewport.clientHeight)
+    })
+
+    cy.screenshot('sprint-11-hotfix-launchpad-guide', { capture: 'viewport' })
+    cy.get('[data-testid="launchpad-guide-close"]').click()
+    cy.get('[data-testid="launchpad-build-monitoring-btn"]').click()
+    cy.location('pathname', { timeout: 10_000 }).should('eq', '/game/build')
+  })
+
+  it('keeps the Earth Base HUD and progression controls in separate hit regions', () => {
+    visitGame('/game/hub', 'hub')
+
+    cy.get('h1', { timeout: 15_000 }).contains('Earth Base').should('be.visible')
+    cy.get('[data-testid="hud-jobs-chip"]').should('be.visible')
+    cy.get('[data-testid="progression-card-skills"]').should('be.visible')
+    cy.get('[data-testid="progression-card-sms"]').should('be.visible')
+    cy.get('[data-testid="progression-card-next-mission"]').should('be.visible')
+    cy.contains('SCANNER').should('not.exist')
+    cy.get('canvas').should('be.visible')
+
+    cy.get('[data-testid="hud-jobs-chip"]').then($hud => {
+      const hud = $hud[0].getBoundingClientRect()
+      cy.get('[data-testid="progression-card-skills"]').then($skills => {
+        expectNoOverlap(hud, $skills[0].getBoundingClientRect(), 'HUD does not overlap Skill Points card')
+      })
+    })
+    cy.get('.hub-push-opt-in').then($prompt => {
+      if ($prompt.is(':visible')) {
+        const prompt = $prompt[0].getBoundingClientRect()
+        cy.get('[data-testid="hud-jobs-chip"]').then($hud => {
+          expectNoOverlap(prompt, $hud[0].getBoundingClientRect(), 'mission alerts do not overlap HUD')
+        })
+      }
+    })
+
+    cy.wait(750)
+    cy.screenshot('sprint-11-hotfix-earth-base', { capture: 'viewport' })
+    cy.get('[data-testid="building-launchpad-hit"]').should('be.visible').and('not.be.disabled')
+  })
+
+  it('does not restore the legacy sidebar on wide desktop viewports', () => {
+    cy.viewport(1720, 1200)
+    visitGame('/game/hub', 'hub')
+
+    cy.get('h1', { timeout: 15_000 }).contains('Earth Base').should('be.visible')
+    cy.get('[data-testid="building-launchpad-hit"]', { timeout: 15_000 }).should('be.visible')
+    cy.get('[data-testid="progression-card-skills"]').should('be.visible')
+    cy.get('[data-testid="progression-card-sms"]').should('be.visible')
+    cy.get('canvas').should('be.visible')
+    cy.get('.desktop-sidebar').should('not.exist')
+    cy.get('[data-testid="settings-button"]')
+      .should('be.visible')
+      .and('have.attr', 'aria-label', 'Settings')
+    cy.window().then(win => {
+      expect(win.document.documentElement.scrollHeight, 'wide hub does not vertically scroll').to.be.at.most(win.innerHeight)
+    })
+
+    cy.wait(750)
+    cy.screenshot('sprint-11-hotfix-earth-base-wide', { capture: 'viewport' })
+  })
+})

--- a/web/lib/content-updates.test.ts
+++ b/web/lib/content-updates.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { Player } from '@/lib/game-types'
+import { contentUpdateTargeting, derivePlayerPlaystyle, parseContentUpdatePayload } from './content-updates'
+
+function player(overrides: Partial<Player> = {}): Player {
+  return {
+    francs: 0,
+    activeMission: null,
+    missionCount: 0,
+    pendingLaunch: false,
+    placed: ['launchpad'],
+    placementPlots: { launchpad: 0 },
+    controlBuilt: false,
+    missionsDone: 1,
+    freeOperations: false,
+    clientMissions: {},
+    clientCooldowns: {},
+    researchAnnotations: 0,
+    refineryBuilt: false,
+    refineryQueue: [],
+    refinedGoods: {},
+    launchpadUpgraded: false,
+    loanDebt: 0,
+    loanOffered: false,
+    ...overrides,
+  }
+}
+
+describe('content update personalisation', () => {
+  it('derives a dominant playstyle from actual program activity', () => {
+    expect(derivePlayerPlaystyle(player({ researchAnnotations: 8 }))).toBe('science')
+    expect(derivePlayerPlaystyle(player({ refineryBuilt: true, refinedGoods: { alloy: 5 } }))).toBe('industry')
+    expect(derivePlayerPlaystyle(player({ hasLanded: true, roverDeployments: [{ roverId: 'r1', targetId: 'eros', clientId: 'c1', timestamp: 1 }] }))).toBe('exploration')
+  })
+
+  it('emits compact PostHog targeting properties', () => {
+    expect(contentUpdateTargeting(player({ freeOperations: true, missionsDone: 8, satelliteMonitoringBuilt: true }))).toMatchObject({
+      landnam_progression_stage: 'established_program',
+      landnam_missions_done: 8,
+      landnam_has_monitoring_station: true,
+    })
+  })
+
+  it('accepts a safe message payload and rejects malformed or unsafe navigation', () => {
+    expect(parseContentUpdatePayload({
+      id: 's12-01',
+      headline: 'Surface operations online',
+      missions: ['Lunar prospecting', 'Lander trials'],
+      impact: 'Your exploration program can now establish surface routes.',
+      ctaLabel: 'Open missions',
+      ctaScreen: 'missions',
+    })).toMatchObject({ id: 's12-01', ctaScreen: 'missions' })
+
+    expect(parseContentUpdatePayload({ id: 'x', headline: 'x', missions: [], impact: 'x' })).toBeNull()
+    expect(parseContentUpdatePayload({ id: 'x', headline: 'x', missions: ['x'], impact: 'x', ctaScreen: 'debrief' }))
+      .toMatchObject({ ctaScreen: undefined })
+  })
+})

--- a/web/lib/content-updates.ts
+++ b/web/lib/content-updates.ts
@@ -1,0 +1,81 @@
+import type { Player, Screen } from '@/lib/game-types'
+
+export const CONTENT_UPDATE_FLAG = 'landnam-content-update'
+
+export type PlayerPlaystyle = 'contracts' | 'science' | 'industry' | 'exploration'
+
+export interface ContentUpdate {
+  id: string
+  headline: string
+  missions: string[]
+  impact: string
+  ctaLabel?: string
+  ctaScreen?: Screen
+}
+
+const CONTENT_UPDATE_SCREENS = new Set<Screen>([
+  'hub', 'missions', 'launchpad', 'galaxy', 'build', 'skills', 'market', 'hangar',
+])
+
+function numericTotal(values: Record<string, number> | undefined): number {
+  return Object.values(values ?? {}).reduce((total, value) => total + Math.max(0, value), 0)
+}
+
+export function derivePlayerPlaystyle(player: Player): PlayerPlaystyle {
+  const scores: Record<PlayerPlaystyle, number> = {
+    contracts: player.missionsDone + numericTotal(player.clientMissions),
+    science: player.researchAnnotations
+      + Object.keys(player.tessClassifications ?? {}).length
+      + Object.keys(player.asteroidClassifications ?? {}).length,
+    industry: (player.refineryBuilt ? 4 : 0)
+      + (player.launchpadUpgraded ? 2 : 0)
+      + numericTotal(player.refinedGoods),
+    exploration: (player.hasLanded ? 3 : 0)
+      + (player.roverDeployments?.length ?? 0)
+      + Object.keys(player.discoveredExoplanetTargets ?? {}).length,
+  }
+
+  return (Object.entries(scores) as Array<[PlayerPlaystyle, number]>)
+    .reduce((best, current) => current[1] > best[1] ? current : best, ['contracts', scores.contracts])[0]
+}
+
+export function contentUpdateTargeting(player: Player): Record<string, string | number | boolean> {
+  const progressionStage = !player.freeOperations
+    ? 'guided_ops'
+    : player.missionsDone < 6
+      ? 'early_free_ops'
+      : 'established_program'
+
+  return {
+    landnam_playstyle: derivePlayerPlaystyle(player),
+    landnam_progression_stage: progressionStage,
+    landnam_missions_done: player.missionsDone,
+    landnam_free_operations: player.freeOperations,
+    landnam_has_monitoring_station: !!player.satelliteMonitoringBuilt,
+    landnam_has_refinery: player.refineryBuilt,
+    landnam_has_landed: !!player.hasLanded,
+    landnam_license_grade: player.licenseGrade ?? 'Grade I',
+  }
+}
+
+export function parseContentUpdatePayload(value: unknown): ContentUpdate | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const payload = value as Record<string, unknown>
+  const id = typeof payload.id === 'string' ? payload.id.trim() : ''
+  const headline = typeof payload.headline === 'string' ? payload.headline.trim() : ''
+  const impact = typeof payload.impact === 'string' ? payload.impact.trim() : ''
+  const missions = Array.isArray(payload.missions)
+    ? payload.missions.filter((mission): mission is string => typeof mission === 'string' && mission.trim().length > 0).slice(0, 4)
+    : []
+
+  if (!id || !headline || !impact || missions.length === 0) return null
+
+  const ctaScreen = typeof payload.ctaScreen === 'string' && CONTENT_UPDATE_SCREENS.has(payload.ctaScreen as Screen)
+    ? payload.ctaScreen as Screen
+    : undefined
+  const ctaLabel = ctaScreen && typeof payload.ctaLabel === 'string' && payload.ctaLabel.trim()
+    ? payload.ctaLabel.trim()
+    : undefined
+
+  return { id, headline, missions, impact, ctaLabel, ctaScreen }
+}

--- a/web/lib/data.test.ts
+++ b/web/lib/data.test.ts
@@ -612,12 +612,12 @@ describe('Scanning station constants and structure seed', () => {
     expect(SCANS_REQUIRED_TO_MAP).toBe(3)
   })
 
-  it('defines a scan-station structure with free cost and freeOperations unlock', () => {
+  it('keeps the Sprint 12 scan-station structure dark in the Sprint 11 build', () => {
     const scanner = STRUCTURES.find(s => s.id === 'scan-station')
     expect(scanner).toBeDefined()
     expect(scanner?.cost).toBe(0)
     expect(scanner && structureUnlocked(scanner, { freeOperations: false })).toBe(false)
-    expect(scanner && structureUnlocked(scanner, { freeOperations: true })).toBe(true)
+    expect(scanner && structureUnlocked(scanner, { freeOperations: true })).toBe(false)
   })
 
   it('scan-station is not unlocked for launchpad-only context', () => {

--- a/web/lib/data/structures.ts
+++ b/web/lib/data/structures.ts
@@ -4,6 +4,7 @@ import type { StructureBlueprint, RefineryRecipe, MarketTemplate } from './types
 import { MINERAL_VALUE, REFINING_COST_RATE, REFINING_VALUE_MULTIPLIER, STRUCTURE_PRICES } from './economy'
 import { MINERAL_RARITY } from './minerals'
 import { CLIENT_AFFINITY_MISSION_THRESHOLD } from './clients'
+import { FEATURE_FLAGS } from '@/lib/featureFlags'
 
 // Refining takes raw ore and returns it worth REFINING_VALUE_MULTIPLIER more,
 // for a cycle fee proportional to the input's value. Previously each recipe
@@ -107,7 +108,7 @@ export function deepSpaceTelescopeUnlocked(opts: { satelliteMonitoringLevel?: nu
 }
 
 export function structureUnlocked(structure: StructureBlueprint, opts: { refineryUnlocked?: boolean; academyResearched?: boolean; placed?: string[]; freeOperations?: boolean; satelliteMonitoringLevel?: number; clientMissions?: Record<string, number> } = {}): boolean {
-  if (structure.id === 'scan-station') return !!opts.freeOperations
+  if (structure.id === 'scan-station') return FEATURE_FLAGS.scanStation && !!opts.freeOperations
   if (structure.id === 'satellite-monitoring-station') return !!opts.freeOperations
   if (structure.id === 'astronaut-academy') return !!opts.academyResearched || !!opts.placed?.includes('astronaut-academy')
   if (structure.id === 'deep-space-telescope') return deepSpaceTelescopeUnlocked(opts) || !!opts.placed?.includes('deep-space-telescope')

--- a/web/lib/featureFlags.ts
+++ b/web/lib/featureFlags.ts
@@ -8,4 +8,9 @@
 export const FEATURE_FLAGS = Object.freeze({
   subsurfaceHabitatTraining:
     process.env.NEXT_PUBLIC_FEATURE_SUBSURFACE_HABITAT_TRAINING === 'true',
+  // The Scan Station mechanic is Sprint 12 work (STS-618). Keep the prepared
+  // screen/code dark in Sprint 11 so an old save cannot make an unbuilt,
+  // non-functional scanner appear on Earth Base.
+  scanStation:
+    process.env.NEXT_PUBLIC_FEATURE_SCAN_STATION === 'true',
 })

--- a/web/lib/game-state.test.ts
+++ b/web/lib/game-state.test.ts
@@ -554,10 +554,12 @@ describe('structure flags are derived from `placed`', () => {
     expect(s.player.satelliteMonitoringBuilt).toBe(true)
   })
 
-  it('repairs refineryBuilt and scannerBuilt the same way', () => {
+  it('repairs refineryBuilt while stripping the deferred scanner from old saves', () => {
     const s = normalizeState({ player: { placed: ['refinery', 'scan-station'] } })
     expect(s.player.refineryBuilt).toBe(true)
-    expect(s.player.scannerBuilt).toBe(true)
+    expect(s.player.scannerBuilt).toBe(false)
+    expect(s.player.placed).toEqual(['refinery'])
+    expect(s.player.placementPlots).not.toHaveProperty('scan-station')
   })
 
   it('leaves the flags false when the structure is not placed', () => {

--- a/web/lib/game-state.ts
+++ b/web/lib/game-state.ts
@@ -5,6 +5,7 @@ import { FREE_OPS_START_MISSIONS_DONE } from '@/lib/data/mission-generator'
 import { migrateCrewRoster } from '@/lib/systems/CrewSystem'
 import { normalizeSurfaceOps } from '@/lib/systems/SurfaceOpsSystem'
 import { settleCrewEconomy } from '@/lib/systems/AcademySystem'
+import { FEATURE_FLAGS } from '@/lib/featureFlags'
 
 // Represents untrusted/partial saved state (e.g. from localStorage or remote sync)
 // where player fields are optional since older saves may be missing new fields.
@@ -179,12 +180,18 @@ export function normalizeState(input: PartialSave): GameState {
   // "Build a Satellite Monitoring Station" they had already built. Derive the
   // flags from `placed` so the two can never drift again — and OR rather than
   // overwrite, so a flag set by any other route still counts.
-  const placedList = Array.isArray(player.placed) ? player.placed : DEFAULT_STATE.player.placed
+  const savedPlaced = Array.isArray(player.placed) ? player.placed : DEFAULT_STATE.player.placed
+  const placedList = FEATURE_FLAGS.scanStation
+    ? savedPlaced
+    : savedPlaced.filter(kind => kind !== 'scan-station')
+  const placementPlots = Object.fromEntries(
+    Object.entries(player.placementPlots ?? {}).filter(([kind]) => FEATURE_FLAGS.scanStation || kind !== 'scan-station')
+  )
   const builtFrom = (kind: string, flag: boolean | undefined) => !!flag || placedList.includes(kind)
   const satelliteMonitoringBuilt = builtFrom('satellite-monitoring-station', player.satelliteMonitoringBuilt)
   const deepSpaceTelescopeBuilt = builtFrom('deep-space-telescope', player.deepSpaceTelescopeBuilt)
   const refineryBuilt = builtFrom('refinery', player.refineryBuilt)
-  const scannerBuilt = builtFrom('scan-station', player.scannerBuilt)
+  const scannerBuilt = FEATURE_FLAGS.scanStation && builtFrom('scan-station', player.scannerBuilt)
   const legacyClaim = input.pendingTerritoryClaimFor as unknown as { targetId: string; clientId?: string; contractorId?: string } | undefined
   const pendingTerritoryClaimFor = legacyClaim
     ? { targetId: legacyClaim.targetId, clientId: legacyClaim.clientId ?? legacyClaim.contractorId ?? '' }
@@ -196,7 +203,7 @@ export function normalizeState(input: PartialSave): GameState {
     missionId,
     targetId,
     rocket: { ...DEFAULT_STATE.rocket, ...input.rocket },
-    player: { ...DEFAULT_STATE.player, ...player, licenseGrade, researchXP, unlockedBlueprints, tessClassifications, asteroidClassifications, discoveredExoplanetTargets, instrumentDigestNotifiedOn, satelliteMonitoringLevel, transitSatelliteLevel, deepSpaceTelescopeLevel, crew, surfaceOps,
+    player: { ...DEFAULT_STATE.player, ...player, placed: placedList, placementPlots, licenseGrade, researchXP, unlockedBlueprints, tessClassifications, asteroidClassifications, discoveredExoplanetTargets, instrumentDigestNotifiedOn, satelliteMonitoringLevel, transitSatelliteLevel, deepSpaceTelescopeLevel, crew, surfaceOps,
       satelliteMonitoringBuilt, deepSpaceTelescopeBuilt, refineryBuilt, scannerBuilt },
     doneSteps: { ...DEFAULT_STATE.doneSteps, ...input.doneSteps },
     ...(pendingTerritoryClaimFor ? { pendingTerritoryClaimFor } : {}),


### PR DESCRIPTION
## What changed

- restores the approved visual Launchpad and Earth Base redesign that never reached `main`
- makes owned infrastructure and the satellite-monitoring build action central to the Launchpad
- removes the legacy desktop sidebar so it cannot overlap the HUD at wide resolutions
- adds a small scene-level Settings control
- adds a minimal PostHog-driven content-update notice with playstyle/progression targeting
- splits the new Launchpad and notification styling into dedicated CSS files

## Root cause

PR #55 deployed correctly, but the two approved Sprint 11 UI commits remained only on `sprint-11-hotfix`. The routed desktop layout also continued mounting the legacy sidebar, allowing its own wide-screen CSS to override the intended hidden state.

## Player impact

Players get the intended scene-first Launchpad, a usable monitoring-station CTA, no required vertical scroll for the essential controls, and no desktop HUD/sidebar collision. New-content notices can be tailored to science, industry, exploration, or contracts-oriented programs without adding a heavy promotional screen.

## Validation

- `npm run typecheck`
- `npm run test:unit` — 54 files / 557 tests passed
- `next build --webpack`
- Docker-backed headed Chrome Sprint 11 visual suite — 3/3 passed at standard and wide desktop viewports

Desk: STS-651, STS-653
