### PR TITLE
feat(auth): email-OTP login for returning users (KES-107)

### DIFF
--- a/web/app/game/(main)/layout.tsx
+++ b/web/app/game/(main)/layout.tsx
@@ -182,6 +182,8 @@ function GameChrome({ children }: { children: ReactNode }) {
             onSignIn={game.signInFromGate}
             onCreateAccount={game.createAccountFromGate}
             onContinue={game.continueWithEmail}
+            otpPending={game.authGateOtpId !== null}
+            onVerifyOtp={game.verifyOtp}
           />
         )}
         {game.pendingTerritoryClaimFor && (

--- a/web/components/game/AuthGateSheet.tsx
+++ b/web/components/game/AuthGateSheet.tsx
@@ -8,15 +8,20 @@ interface AuthGateSheetProps {
   onSignIn: (email: string, password: string) => Promise<void>
   onCreateAccount: (email: string, password: string) => Promise<void>
   onContinue: (email: string) => Promise<void>
+  /** True once onContinue's requestOTP() succeeded — switches the quick path to code entry. */
+  otpPending: boolean
+  onVerifyOtp: (code: string) => Promise<void>
 }
 
-export default function AuthGateSheet({ error, onSignIn, onCreateAccount, onContinue }: AuthGateSheetProps) {
+export default function AuthGateSheet({ error, onSignIn, onCreateAccount, onContinue, otpPending, onVerifyOtp }: AuthGateSheetProps) {
   const [mode, setMode] = useState<'signin' | 'signup'>('signin')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [quickEmail, setQuickEmail] = useState('')
   const [quickSubmitting, setQuickSubmitting] = useState(false)
+  const [otpCode, setOtpCode] = useState('')
+  const [otpSubmitting, setOtpSubmitting] = useState(false)
 
   const inputStyle: React.CSSProperties = {
     width: '100%', padding: '12px 14px',
@@ -52,6 +57,18 @@ export default function AuthGateSheet({ error, onSignIn, onCreateAccount, onCont
       // error shown via props
     } finally {
       setQuickSubmitting(false)
+    }
+  }
+
+  async function handleVerifyOtp(e: React.FormEvent) {
+    e.preventDefault()
+    setOtpSubmitting(true)
+    try {
+      await onVerifyOtp(otpCode)
+    } catch {
+      // error shown via props
+    } finally {
+      setOtpSubmitting(false)
     }
   }
 
@@ -145,36 +162,74 @@ export default function AuthGateSheet({ error, onSignIn, onCreateAccount, onCont
         </form>
 
         <div style={{ marginTop: 16, paddingTop: 14, borderTop: '1px solid rgba(112,217,234,0.15)' }}>
-          <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 11, color: '#5d7390', marginBottom: 8, textAlign: 'center' }}>
-            Or just leave an email — no password needed
-          </div>
-          <form onSubmit={handleQuickContinue} style={{ display: 'flex', gap: 8 }}>
-            <input
-              type="email"
-              value={quickEmail}
-              onChange={e => setQuickEmail(e.target.value)}
-              required
-              autoComplete="email"
-              placeholder="you@example.com"
-              data-testid="auth-gate-quick-email"
-              style={{ ...inputStyle, flex: 1 }}
-            />
-            <button
-              type="submit"
-              disabled={quickSubmitting}
-              data-testid="auth-gate-quick-submit"
-              style={{
-                padding: '0 18px', borderRadius: 10, border: '1px solid rgba(112,217,234,0.35)',
-                cursor: quickSubmitting ? 'not-allowed' : 'pointer',
-                background: 'transparent', color: '#87CFFA',
-                fontFamily: 'var(--ln-font-display)', fontSize: 12, fontWeight: 800,
-                letterSpacing: '0.1em', textTransform: 'uppercase',
-                opacity: quickSubmitting ? 0.6 : 1,
-              }}
-            >
-              {quickSubmitting ? '…' : 'Continue'}
-            </button>
-          </form>
+          {otpPending ? (
+            <>
+              <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 11, color: '#5d7390', marginBottom: 8, textAlign: 'center' }}>
+                Enter the code we emailed to {quickEmail}
+              </div>
+              <form onSubmit={handleVerifyOtp} style={{ display: 'flex', gap: 8 }}>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={otpCode}
+                  onChange={e => setOtpCode(e.target.value)}
+                  required
+                  autoComplete="one-time-code"
+                  placeholder="Code"
+                  data-testid="auth-gate-otp-code"
+                  style={{ ...inputStyle, flex: 1 }}
+                />
+                <button
+                  type="submit"
+                  disabled={otpSubmitting}
+                  data-testid="auth-gate-otp-submit"
+                  style={{
+                    padding: '0 18px', borderRadius: 10, border: '1px solid rgba(112,217,234,0.35)',
+                    cursor: otpSubmitting ? 'not-allowed' : 'pointer',
+                    background: 'transparent', color: '#87CFFA',
+                    fontFamily: 'var(--ln-font-display)', fontSize: 12, fontWeight: 800,
+                    letterSpacing: '0.1em', textTransform: 'uppercase',
+                    opacity: otpSubmitting ? 0.6 : 1,
+                  }}
+                >
+                  {otpSubmitting ? '…' : 'Verify'}
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              <div style={{ fontFamily: 'var(--ln-font-body)', fontSize: 11, color: '#5d7390', marginBottom: 8, textAlign: 'center' }}>
+                Or just leave an email — no password needed
+              </div>
+              <form onSubmit={handleQuickContinue} style={{ display: 'flex', gap: 8 }}>
+                <input
+                  type="email"
+                  value={quickEmail}
+                  onChange={e => setQuickEmail(e.target.value)}
+                  required
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                  data-testid="auth-gate-quick-email"
+                  style={{ ...inputStyle, flex: 1 }}
+                />
+                <button
+                  type="submit"
+                  disabled={quickSubmitting}
+                  data-testid="auth-gate-quick-submit"
+                  style={{
+                    padding: '0 18px', borderRadius: 10, border: '1px solid rgba(112,217,234,0.35)',
+                    cursor: quickSubmitting ? 'not-allowed' : 'pointer',
+                    background: 'transparent', color: '#87CFFA',
+                    fontFamily: 'var(--ln-font-display)', fontSize: 12, fontWeight: 800,
+                    letterSpacing: '0.1em', textTransform: 'uppercase',
+                    opacity: quickSubmitting ? 0.6 : 1,
+                  }}
+                >
+                  {quickSubmitting ? '…' : 'Continue'}
+                </button>
+              </form>
+            </>
+          )}
         </div>
     </Sheet>
   )

--- a/web/components/game/GameApp.tsx
+++ b/web/components/game/GameApp.tsx
@@ -254,6 +254,8 @@ function GameCanvas() {
             onSignIn={game.signInFromGate}
             onCreateAccount={game.createAccountFromGate}
             onContinue={game.continueWithEmail}
+            otpPending={game.authGateOtpId !== null}
+            onVerifyOtp={game.verifyOtp}
           />
         )}
         {game.pendingTerritoryClaimFor && (

--- a/web/game-context.tsx
+++ b/web/game-context.tsx
@@ -180,6 +180,8 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       signInFromGate: auth.signInFromGate,
       createAccountFromGate: auth.createAccountFromGate,
       continueWithEmail: auth.continueWithEmail,
+      authGateOtpId: auth.authGateOtpId,
+      verifyOtp: auth.verifyOtp,
       resetGame: useCallback(() => { void auth.resetGame(DEFAULT_STATE) }, [auth.resetGame]), // eslint-disable-line react-hooks/rules-of-hooks
       signOut: auth.signOut,
       // Game loop

--- a/web/lib/contexts/useAuthSync.ts
+++ b/web/lib/contexts/useAuthSync.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import type { RecordModel } from 'pocketbase'
 import { pbShared } from '@/lib/pb'
 import { pbLandnam, exchangeLandnamAuth } from '@/lib/pb-landnam'
-import { ensureGuestAuth, hasStoredCredentials, isGuestAccount, upgradeGuestAccount, createAccountWithEmail } from '@/lib/guestAuth'
+import { ensureGuestAuth, hasStoredCredentials, isGuestAccount, upgradeGuestAccount } from '@/lib/guestAuth'
 import { identifyUser } from '@/lib/posthog'
 import { DEFAULT_STATE, mergeRemoteState, type PartialSave } from '@/lib/game-state'
 import type { GameState } from '@/lib/game-types'
@@ -77,6 +77,10 @@ export function useAuthSync({
   const [awaitingRemoteState, setAwaitingRemoteState] = useState(false)
   const [authGateOpen, setAuthGateOpen] = useState(false)
   const [authGateError, setAuthGateError] = useState<string | null>(null)
+  // Set once requestOTP() succeeds; its presence is what switches the gate's
+  // quick-continue step from "enter email" to "enter code". Cleared on gate
+  // close/reopen so a stale otpId from a previous email can't be submitted.
+  const [authGateOtpId, setAuthGateOtpId] = useState<string | null>(null)
   // The gate must not decide that a returning user is anonymous until the
   // persisted PocketBase auth store has had a chance to restore. Keeping this
   // as an explicit phase prevents the sign-in sheet flashing/reopening during
@@ -498,18 +502,44 @@ export function useAuthSync({
   // Replaces the old anonymous "continue as guest" skip (KES-97): the gate
   // now always requires at least an email before play continues, even on the
   // lightweight path — no account with no way to contact the player.
+  //
+  // KES-107: this is now a two-step OTP flow (requestOTP then authWithOTP)
+  // instead of always creating a brand-new account, so the same "just an
+  // email" input works for both first-time signup and returning login on a
+  // new device. The shared backend's OnRecordRequestOTPRequest("users") hook
+  // (main.go) auto-creates the record server-side when the email doesn't
+  // match an existing account yet, so requestOTP() below succeeds either way
+  // — the client never needs to know in advance which case it is.
   const continueWithEmail = useCallback(async (email: string) => {
     setAuthGateError(null)
     try {
-      await createAccountWithEmail(email)
-      authGateDismissed.current = true
-      setAuthGateOpen(false)
+      const { otpId } = await pbShared.collection('users').requestOTP(email)
+      setAuthGateOtpId(otpId)
     } catch (e) {
       const msg = authErrorMessage(e, 'Could not continue — check your email and try again')
       setAuthGateError(msg)
       throw new Error(msg)
     }
   }, [])
+
+  const verifyOtp = useCallback(async (code: string) => {
+    if (!authGateOtpId) {
+      const msg = 'Request a new code and try again'
+      setAuthGateError(msg)
+      throw new Error(msg)
+    }
+    setAuthGateError(null)
+    try {
+      await pbShared.collection('users').authWithOTP(authGateOtpId, code)
+      setAuthGateOtpId(null)
+      authGateDismissed.current = true
+      setAuthGateOpen(false)
+    } catch (e) {
+      const msg = authErrorMessage(e, 'Incorrect or expired code — try again')
+      setAuthGateError(msg)
+      throw new Error(msg)
+    }
+  }, [authGateOtpId])
 
   const resetGame = useCallback(async (defaultState: GameState) => {
     setState(defaultState)
@@ -565,6 +595,7 @@ export function useAuthSync({
     setAwaitingRemoteState(false)
     setUpgradePromptOpen(false)
     setAuthGateError(null)
+    setAuthGateOtpId(null)
     authGateDismissed.current = false
     if (!isPreview) setAuthGateOpen(true)
   }, [addToast, authUserId, backendReady, isPreview, saveRemoteState, setState, stateRef, storageKey])
@@ -575,6 +606,7 @@ export function useAuthSync({
     upgradePromptOpen, upgradeAccount,
     awaitingRemoteState,
     authGateOpen, authGateError, signInFromGate, createAccountFromGate, continueWithEmail,
+    authGateOtpId, verifyOtp,
     resetGame, signOut,
   }
 }

--- a/web/lib/game-types.ts
+++ b/web/lib/game-types.ts
@@ -285,6 +285,8 @@ export interface GameActions {
   signInFromGate: (email: string, password: string) => Promise<void>
   createAccountFromGate: (email: string, password: string) => Promise<void>
   continueWithEmail: (email: string) => Promise<void>
+  authGateOtpId: string | null
+  verifyOtp: (code: string) => Promise<void>
   go: (screen: Screen) => void
   goToMissions: () => void
   setScreenFromUrl: (screen: Screen) => void


### PR DESCRIPTION
## Summary
- Backend (`~/Navigation/backend`, already deployed to `signal-k-starsailors.fly.dev`): `OnRecordRequestOTPRequest("users")` hook auto-creates an account when `requestOTP()` is called with an unmatched email, and a migration enables OTP on the `users` collection.
- Frontend: the auth gate's "Continue" quick-path is now a two-step OTP flow (email → code) via `requestOTP`/`authWithOTP`, replacing the signup-only `createAccountWithEmail` path — so the same email works for both first-time signup and returning cross-device login, no password ever required.
- Fixes a real bug: previously, a returning player re-entering their email on a different device hit a duplicate-email error instead of logging back in.

Supersedes part of KES-97's "no passwordless/magic-link rework" call — see ZenNotes decision `landnam-auth-continue-with-email-reverses-to-otp-login-2026-08-05`.

## Test plan
- [x] Backend builds clean (`go build ./...`), deployed to prod, verified live: `requestOTP` with a brand-new email auto-created the account and returned a real `otpId` (confirmed via PocketBase admin API, test record cleaned up after).
- [x] Frontend typechecks clean (`npx tsc --noEmit`).
- [ ] Manual smoke test of the full UI flow (email → code → verified session) once SMTP is configured — mail delivery is currently disabled on the shared backend (separate blocker, tracked in KES-107).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>