### PR TITLE
fix: make mobile game canvas full-bleed instead of a shrunk boxed card

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -325,6 +325,14 @@ button { cursor: pointer; }
   padding: var(--ln-s-4);
   background: radial-gradient(ellipse at 30% -15%, #2c2c30 0%, #1c1c1f 45%, #08080a 80%);
 }
+/* Below the desktop breakpoint the device itself IS the phone — the padded,
+   bordered "phone card floating in a browser" treatment below was designed
+   for shrinking a desktop window, not for real mobile viewports, and on an
+   actual phone it just wastes screen as dead margin around a shrunk canvas.
+   Drop the stage padding here so .portrait-canvas can go full-bleed. */
+@media (max-width: 1023px) {
+  .game-stage { padding: 0; }
+}
 .game-stage::before {
   content: '';
   position: fixed;
@@ -354,6 +362,22 @@ button { cursor: pointer; }
   border-radius: 28px;
   box-shadow: var(--ln-shadow-modal), var(--ln-glow-cyan);
   isolation: isolate;
+}
+/* Real mobile viewports (and a resized-narrow desktop window, which shares
+   this breakpoint) get the full device screen, not a shrunk card with dead
+   margin around it — the 402x874 card above is a "phone mockup" treatment
+   that only makes sense once there's a larger frame around it to mock up
+   inside of. Safe-area padding for installed-PWA standalone mode is added
+   separately via body[data-pwa="standalone"] .portrait-canvas. */
+@media (max-width: 1023px) {
+  .portrait-canvas {
+    width: 100%;
+    height: 100dvh;
+    max-height: none;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
 }
 
 /* Flex row above .bottom-tab-bar — screen content's own overflow-y:auto
@@ -1075,7 +1099,6 @@ button { cursor: pointer; }
 .reward-xp { margin-top: var(--ln-s-2); color: var(--ln-info); font: 700 12px var(--ln-font-mono); letter-spacing: var(--ln-tr-label); }
 
 @media (max-height: 760px) and (max-width: 1023px) {
-  .portrait-canvas { border-radius: var(--ln-r-xl); }
   .screen-scroll { padding-top: 68px; }
   .screen-scroll--coach { padding-top: var(--tutorial-content-top); }
   .screen-scroll--coach-manual { padding-top: var(--tutorial-manual-content-top); }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -674,6 +674,28 @@ button { cursor: pointer; }
 .compatibility--bad { color: var(--ln-crit); border: 1px solid var(--ln-crit); background: var(--ln-crit-soft); }
 .sticky-actions { position: absolute; z-index: 30; left: 0; right: 0; bottom: 0; padding: var(--ln-s-2) var(--ln-s-3) var(--ln-s-5); background: linear-gradient(180deg, transparent, rgba(10,10,11,.94) 34%, var(--ln-void)); }
 
+/* Step wayfinding footer (StepFooter.tsx) — desktop-sized defaults, matching
+   the values that used to be inline. Mobile gets a tighter pass below: this
+   strip sits directly above the primary CTA in .sticky-actions, so on a
+   narrow phone every px it takes is a px the thumb-reachable button loses. */
+.step-footer--inline { gap: 8px; padding: 8px 12px; }
+.step-footer-pills { display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; }
+.step-footer-arrow { font-size: 13px; color: var(--ln-text-muted); opacity: .6; }
+.step-footer-pill { font: 800 12px var(--ln-font-display); letter-spacing: .04em; padding: 7px 16px; border-radius: 999px; white-space: nowrap; }
+.step-footer-caption { font: 800 9px var(--ln-font-display); letter-spacing: .18em; color: var(--ln-text-muted); text-transform: uppercase; }
+.step-footer-desc { font: 400 11px var(--ln-font-body); color: var(--ln-text-dim); opacity: .8; line-height: 1.35; max-width: 560px; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow: hidden; }
+
+@media (max-width: 1023px) {
+  /* Fewer, smaller words in the wayfinding strip: current step's name is
+     still the one filled-in pill, but the row no longer competes with the
+     Purchase/Launch button beneath it for thumb space or attention. */
+  .step-footer--inline { gap: 6px; padding: 6px 10px; }
+  .step-footer-pills { gap: 4px; }
+  .step-footer-arrow { font-size: 10px; }
+  .step-footer-pill { font-size: 10px; padding: 5px 10px; }
+  .step-footer-desc { -webkit-line-clamp: 1; }
+}
+
 .mission-setup-screen {
   /* Keep the shared game-screen viewport contract; the scene layer itself
      is positioned relative to this full-area screen. */

--- a/web/components/game/StepFooter.tsx
+++ b/web/components/game/StepFooter.tsx
@@ -38,23 +38,19 @@ interface StepFooterProps {
 // done = green text, future = dim with border.
 function StepPills({ idx }: { idx: number }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }} aria-hidden="true">
+    <div className="step-footer-pills" aria-hidden="true">
       {STEP_SEQUENCE.map((s, i) => (
         <React.Fragment key={s}>
-          {i > 0 && (
-            <span style={{ fontSize: 13, color: 'var(--ln-text-muted)', opacity: 0.6 }}>→</span>
-          )}
+          {i > 0 && <span className="step-footer-arrow">→</span>}
           <span
-            style={{
-              fontFamily: 'var(--ln-font-display)', fontWeight: 800, fontSize: 12,
-              letterSpacing: '0.04em',
-              padding: '7px 16px', borderRadius: 999, whiteSpace: 'nowrap',
-              ...(i === idx
+            className="step-footer-pill"
+            style={
+              i === idx
                 ? { background: 'var(--ln-cyan)', color: 'var(--ln-text-on-cyan)', border: '1px solid transparent' }
                 : i < idx
                   ? { background: 'transparent', color: 'var(--ln-ok)', border: '1px solid rgba(90,208,126,0.3)' }
-                  : { background: 'transparent', color: 'var(--ln-text-muted)', border: '1px solid var(--ln-hairline-strong)' }),
-            }}
+                  : { background: 'transparent', color: 'var(--ln-text-muted)', border: '1px solid var(--ln-hairline-strong)' }
+            }
           >
             {s}
           </span>
@@ -68,15 +64,18 @@ export default function StepFooter({ step, description, inline = false }: StepFo
   const idx = STEP_SEQUENCE.indexOf(step)
   return (
     <aside
+      className={`step-footer ${inline ? 'step-footer--inline' : 'step-footer--strip'}`}
       data-testid="step-footer"
       data-step={step.toLowerCase()}
       aria-label={`Mission flow: ${step}, step ${idx + 1} of ${STEP_SEQUENCE.length}`}
       style={inline ? {
-        display: 'flex', flexDirection: 'column', gap: 8,
-        padding: '8px 12px',
+        display: 'flex', flexDirection: 'column',
         borderRadius: 8,
         background: 'var(--ln-shell, var(--ln-surface))',
         border: '1px solid var(--ln-hairline-strong)',
+        // gap + padding live in the .step-footer--inline CSS class (globals.css)
+        // instead of here so the mobile breakpoint can tighten them — an
+        // inline style value can't be overridden by a media query.
       } : {
         // Centered strip, matching the Open Design shells (landnam-mission-board.html):
         // "STEP 1 OF 4" caption centered above a centered row of step pills.
@@ -89,19 +88,11 @@ export default function StepFooter({ step, description, inline = false }: StepFo
         textAlign: 'center',
       }}
     >
-      <div style={{
-        fontFamily: 'var(--ln-font-display)', fontSize: 9, fontWeight: 800,
-        letterSpacing: '0.18em', color: 'var(--ln-text-muted)', textTransform: 'uppercase',
-      }}>
+      <div className="step-footer-caption">
         Step {idx + 1} of {STEP_SEQUENCE.length}
       </div>
       <StepPills idx={idx} />
-      <div style={{
-        fontFamily: 'var(--ln-font-body)', fontSize: 11, color: 'var(--ln-text-dim)',
-        opacity: 0.8, lineHeight: 1.35, maxWidth: 560,
-        display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 2,
-        overflow: 'hidden',
-      }}>
+      <div className="step-footer-desc">
         {description}
       </div>
     </aside>

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -63,7 +63,11 @@ export function GhostBtn({ children, onClick, full = true, testId }: ButtonProps
       onClick={onClick}
       style={{
         width: full ? '100%' : 'auto',
+        minHeight: 44, // touch-target floor (Apple HIG / WCAG 2.5.5)
         padding: '12px 18px',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         background: 'rgba(20,20,23,0.6)',
         color: '#a9b8ce',
         fontFamily: 'var(--ln-font-display)',
@@ -87,7 +91,7 @@ export function IconBtn({
   ariaLabel,
   testId,
   color = '#cde4ff',
-  size = 38,
+  size = 44, // touch-target floor (Apple HIG / WCAG 2.5.5) — was 38
 }: {
   children: React.ReactNode
   onClick?: () => void


### PR DESCRIPTION
Below the 1024px desktop breakpoint, .portrait-canvas was capped at
402x874 and centered inside a padded .game-stage with a rounded
border/shadow — a "phone mockup in a browser window" treatment that
made sense for a resized desktop window but wasted real screen space
as dead margin on an actual mobile device, and left the content area
visibly boxed-in and undersized on phones.

.portrait-canvas and .game-stage now go full-bleed (100% width,
100dvh, no border/radius/shadow/padding) for any viewport under
1024px; the intentional centered-card treatment at desktop widths
(>=1024px) is untouched.

Note: Linear MCP tooling was not available in this session, so no
KES- issue could be created or updated per the repo's Linear-first
workflow — flagging for manual follow-up.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V8go9W8LJ2b4CE6S9cfqsS